### PR TITLE
Expand file extension dictionary

### DIFF
--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -36,19 +36,31 @@
 #' ext_text()
 ext_text <- function(flat = FALSE) {
   x <- list(
-    "r" = c("R", "r", "s"),
+    "r" = c("R", "r", "s", "q"),
     "man" = c("Rd", "rd"),
     "manfigures" = c("svg"),
     "src" = c(
-      "c", "h", "cpp", "hpp", "hxx", "hh",
-      "f", "f90", "f95", "f03"
+      "c", "h", "cpp", "cc", "hpp", "hxx", "hh",
+      "f", "f90", "f95", "f03",
+      "win", "in", "ucrt", "ac"
     ),
-    "vignette" = c("Rmd", "md", "Rnw", "tex", "bib"),
-    "meta" = c("Rproj", "dcf", "yml", "yaml"),
+    "vignette" = c(
+      "Rmd", "md", "csl", "Rnw", "tex", "ltx", "rsp", "cls", "sty",
+      "bib", "bst", "asis", "el"
+    ),
+    "meta" = c("Rproj", "dcf", "yml", "yaml", "note"),
     "table" = c("csv", "tsv", "txt"),
     "figure" = c("svg"),
-    "web" = c("html", "css", "js", "xml"),
-    "doc" = c("rtf")
+    "web" = c("html", "htm", "shtml", "css", "js", "json", "xml", "scss", "less"),
+    "doc" = c("rtf"),
+    "log" = c("save", "Rout"),
+    "proglang" = c(
+      "stan", "bug", "jags", "py", "ipynb", "sh", "java", "bat", "m4", "cmake",
+      "sql", "lua", "rs", "jl", "pl", "pm"
+    ),
+    "gettext" = c("po", "pot"),
+    "geo" = c("geojson", "kml", "prj", "cpg", "qpj"),
+    "bio" = c("fasta", "fastq", "vcf", "ped", "bim", "fam", "gff", "gtf")
   )
   if (flat) unique(unlist(x)) else x
 }
@@ -76,12 +88,24 @@ ext_binary <- function(flat = FALSE) {
     "data" = c("rda", "rds", "RData"),
     "manfigures" = c("jpg", "jpeg", "pdf", "png"),
     "figure" = c(
-      "png", "jpg", "jpeg", "bmp", "gif", "tiff", "emf",
-      "ico", "webp", "eps", "pdf"
+      "png", "jpg", "jpeg", "bmp", "gif", "tif", "tiff", "emf", "svgz",
+      "ico", "webp", "eps", "pdf",
+      "ppm", "pgm", "pbm", "pnm"
     ),
     "src" = c("o", "so"),
-    "mso" = c("docx", "xlsx", "pptx", "doc", "xls", "ppt"),
-    "sas" = c("sas7bdat", "sas7bcat", "xpt", "xpt5", "xpt8")
+    "build" = c("rdb", "rdx"),
+    "web" = c("woff2", "woff", "otf", "ttf", "eot"),
+    "mso" = c("docx", "xlsx", "pptx", "xltx", "potx", "doc", "xls", "ppt"),
+    "odf" = c("odt", "ods", "odp", "odg", "odc", "odf", "odi", "odm", "odb"),
+    "sas" = c("sas7bdat", "sas7bcat", "xpt", "xpt5", "xpt8"),
+    "archive" = c("zip", "tar", "gz", "tgz", "bz2", "7z", "xz"),
+    "db" = c("sqlite", "sqlite3"),
+    "proglang" = c("pyc", "jar"),
+    "gettext" = c("mo"),
+    "geo" = c("shx", "shp", "laz", "sbx", "sbn", "nc", "gpkg"),
+    "bio" = c("bam", "bai"),
+    "audio" = c("wav", "mp3", "mid", "ogg", "au", "m4a"),
+    "video" = c("mp4", "avi", "mov", "mkv", "webm")
   )
   if (flat) unique(unlist(x)) else x
 }
@@ -110,11 +134,22 @@ pattern_file_root_core <- function() {
     "^DESCRIPTION$",
     "^NAMESPACE$",
     "^README$",
+    "^README\\.Rmd$",
     "^README\\.md$",
     "^NEWS$",
     "^NEWS\\.md$",
     "^LICENSE$",
-    "\\.Rbuildignore$"
+    "^LICENCE$",
+    "^LICENSE\\.note$",
+    "^LICENCE\\.note$",
+    "\\.Rbuildignore$",
+    "\\.Rinstignore$",
+    "^configure$",
+    "^configure\\.win$",
+    "^configure\\.ac$",
+    "^configure\\.in$",
+    "^cleanup$",
+    "^cleanup\\.win$"
   )
 }
 
@@ -127,6 +162,9 @@ pattern_file_root_all <- function() {
     "^README$",
     "^NEWS$",
     "^LICENSE$",
+    "^LICENCE$",
+    "^configure$",
+    "^cleanup$",
     "*[.]"
   )
 }

--- a/tests/testthat/test-independent-test_dictionary.R
+++ b/tests/testthat/test-independent-test_dictionary.R
@@ -1,18 +1,30 @@
 test_that("Test ext_text() generate the right string list", {
   str_ls <- list(
-    "r" = c("R", "r", "s"),
+    "r" = c("R", "r", "s", "q"),
     "man" = c("Rd", "rd"),
     "manfigures" = c("svg"),
     "src" = c(
-      "c", "h", "cpp", "hpp", "hxx", "hh",
-      "f", "f90", "f95", "f03"
+      "c", "h", "cpp", "cc", "hpp", "hxx", "hh",
+      "f", "f90", "f95", "f03",
+      "win", "in", "ucrt", "ac"
     ),
-    "vignette" = c("Rmd", "md", "Rnw", "tex", "bib"),
-    "meta" = c("Rproj", "dcf", "yml", "yaml"),
+    "vignette" = c(
+      "Rmd", "md", "csl", "Rnw", "tex", "ltx", "rsp", "cls", "sty",
+      "bib", "bst", "asis", "el"
+    ),
+    "meta" = c("Rproj", "dcf", "yml", "yaml", "note"),
     "table" = c("csv", "tsv", "txt"),
     "figure" = c("svg"),
-    "web" = c("html", "css", "js", "xml"),
-    "doc" = c("rtf")
+    "web" = c("html", "htm", "shtml", "css", "js", "json", "xml", "scss", "less"),
+    "doc" = c("rtf"),
+    "log" = c("save", "Rout"),
+    "proglang" = c(
+      "stan", "bug", "jags", "py", "ipynb", "sh", "java", "bat", "m4", "cmake",
+      "sql", "lua", "rs", "jl", "pl", "pm"
+    ),
+    "gettext" = c("po", "pot"),
+    "geo" = c("geojson", "kml", "prj", "cpg", "qpj"),
+    "bio" = c("fasta", "fastq", "vcf", "ped", "bim", "fam", "gff", "gtf")
   )
 
   ls_target <- str_ls
@@ -30,12 +42,24 @@ test_that("Test ext_binary() generate the right string list", {
     "data" = c("rda", "rds", "RData"),
     "manfigures" = c("jpg", "jpeg", "pdf", "png"),
     "figure" = c(
-      "png", "jpg", "jpeg", "bmp", "gif", "tiff", "emf",
-      "ico", "webp", "eps", "pdf"
+      "png", "jpg", "jpeg", "bmp", "gif", "tif", "tiff", "emf", "svgz",
+      "ico", "webp", "eps", "pdf",
+      "ppm", "pgm", "pbm", "pnm"
     ),
     "src" = c("o", "so"),
-    "mso" = c("docx", "xlsx", "pptx", "doc", "xls", "ppt"),
-    "sas" = c("sas7bdat", "sas7bcat", "xpt", "xpt5", "xpt8")
+    "build" = c("rdb", "rdx"),
+    "web" = c("woff2", "woff", "otf", "ttf", "eot"),
+    "mso" = c("docx", "xlsx", "pptx", "xltx", "potx", "doc", "xls", "ppt"),
+    "odf" = c("odt", "ods", "odp", "odg", "odc", "odf", "odi", "odm", "odb"),
+    "sas" = c("sas7bdat", "sas7bcat", "xpt", "xpt5", "xpt8"),
+    "archive" = c("zip", "tar", "gz", "tgz", "bz2", "7z", "xz"),
+    "db" = c("sqlite", "sqlite3"),
+    "proglang" = c("pyc", "jar"),
+    "gettext" = c("mo"),
+    "geo" = c("shx", "shp", "laz", "sbx", "sbn", "nc", "gpkg"),
+    "bio" = c("bam", "bai"),
+    "audio" = c("wav", "mp3", "mid", "ogg", "au", "m4a"),
+    "video" = c("mp4", "avi", "mov", "mkv", "webm")
   )
 
   ls_target <- str_ls
@@ -53,11 +77,22 @@ test_that("Test pattern_file_root_core() generate the right string list", {
     "^DESCRIPTION$",
     "^NAMESPACE$",
     "^README$",
+    "^README\\.Rmd$",
     "^README\\.md$",
     "^NEWS$",
     "^NEWS\\.md$",
     "^LICENSE$",
-    "\\.Rbuildignore$"
+    "^LICENCE$",
+    "^LICENSE\\.note$",
+    "^LICENCE\\.note$",
+    "\\.Rbuildignore$",
+    "\\.Rinstignore$",
+    "^configure$",
+    "^configure\\.win$",
+    "^configure\\.ac$",
+    "^configure\\.in$",
+    "^cleanup$",
+    "^cleanup\\.win$"
   )
 
   ls_target <- str_ls
@@ -73,6 +108,9 @@ test_that("Test pattern_file_root_all() generate the right string list", {
     "^README$",
     "^NEWS$",
     "^LICENSE$",
+    "^LICENCE$",
+    "^configure$",
+    "^cleanup$",
     "*[.]"
   )
 

--- a/tests/testthat/test-independent-test_templates.R
+++ b/tests/testthat/test-independent-test_templates.R
@@ -63,7 +63,7 @@ testthat::test_that("file_root_core() creates the correct 'file_spec' object", {
   is_root_core <- is_file_spec_type(
     fs_source = file_root_core(),
     path = "",
-    pattern = "^DESCRIPTION$|^NAMESPACE$|^README$|^README\\.md$|^NEWS$|^NEWS\\.md$|^LICENSE$|\\.Rbuildignore$",
+    pattern = "^DESCRIPTION$|^NAMESPACE$|^README$|^README\\.Rmd$|^README\\.md$|^NEWS$|^NEWS\\.md$|^LICENSE$|^LICENCE$|^LICENSE\\.note$|^LICENCE\\.note$|\\.Rbuildignore$|\\.Rinstignore$|^configure$|^configure\\.win$|^configure\\.ac$|^configure\\.in$|^cleanup$|^cleanup\\.win$",
     format = "text",
     recursive = FALSE,
     ignore_case = FALSE,
@@ -78,7 +78,7 @@ testthat::test_that("file_root_all() creates the correct 'file_spec' object", {
   is_root_all <- is_file_spec_type(
     fs_source = file_root_all(),
     path = "",
-    pattern = "^DESCRIPTION$|^NAMESPACE$|^README$|^NEWS$|^LICENSE$|*[.]",
+    pattern = "^DESCRIPTION$|^NAMESPACE$|^README$|^NEWS$|^LICENSE$|^LICENCE$|^configure$|^cleanup$|*[.]",
     format = "text",
     recursive = FALSE,
     ignore_case = TRUE,
@@ -102,7 +102,7 @@ testthat::test_that("file_r() creates the correct 'file_spec' objects", {
       if (!is_spec_code & is_file_spec_type(
         fs_source = fs,
         path = "R/",
-        pattern = "\\.R$|\\.r$|\\.s$",
+        pattern = "\\.R$|\\.r$|\\.s$|\\.q$",
         format = "text",
         recursive = FALSE,
         ignore_case = TRUE,
@@ -195,7 +195,7 @@ testthat::test_that("file_src() creates the correct 'file_spec' object", {
   is_src <- is_file_spec_type(
     fs_source = file_src(),
     path = "src/",
-    pattern = "\\.c$|\\.h$|\\.cpp$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$",
+    pattern = "\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$",
     format = "text",
     recursive = TRUE,
     ignore_case = TRUE,
@@ -234,7 +234,7 @@ testthat::test_that("file_vignettes() creates the correct 'file_spec' objects", 
       if (!is_spec_text & is_file_spec_type(
         fs_source = fs,
         path = "vignettes/",
-        pattern = "\\.R$|\\.r$|\\.s$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.Rmd$|\\.md$|\\.Rnw$|\\.tex$|\\.bib$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.csv$|\\.tsv$|\\.txt$|\\.html$|\\.css$|\\.js$|\\.xml$|\\.rtf$",
+        pattern = "\\.R$|\\.r$|\\.s$|\\.q$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.Rmd$|\\.md$|\\.csl$|\\.Rnw$|\\.tex$|\\.ltx$|\\.rsp$|\\.cls$|\\.sty$|\\.bib$|\\.bst$|\\.asis$|\\.el$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.note$|\\.csv$|\\.tsv$|\\.txt$|\\.html$|\\.htm$|\\.shtml$|\\.css$|\\.js$|\\.json$|\\.xml$|\\.scss$|\\.less$|\\.rtf$|\\.save$|\\.Rout$|\\.stan$|\\.bug$|\\.jags$|\\.py$|\\.ipynb$|\\.sh$|\\.java$|\\.bat$|\\.m4$|\\.cmake$|\\.sql$|\\.lua$|\\.rs$|\\.jl$|\\.pl$|\\.pm$|\\.po$|\\.pot$|\\.geojson$|\\.kml$|\\.prj$|\\.cpg$|\\.qpj$|\\.fasta$|\\.fastq$|\\.vcf$|\\.ped$|\\.bim$|\\.fam$|\\.gff$|\\.gtf$",
         format = "text",
         recursive = TRUE,
         ignore_case = TRUE,
@@ -247,7 +247,7 @@ testthat::test_that("file_vignettes() creates the correct 'file_spec' objects", 
       (!is_spec_binary & is_file_spec_type(
           fs_source = fs,
           path = "vignettes/",
-          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tiff$|\\.emf$|\\.ico$|\\.webp$|\\.eps$|\\.o$|\\.so$|\\.docx$|\\.xlsx$|\\.pptx$|\\.doc$|\\.xls$|\\.ppt$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$",
+          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tif$|\\.tiff$|\\.emf$|\\.svgz$|\\.ico$|\\.webp$|\\.eps$|\\.ppm$|\\.pgm$|\\.pbm$|\\.pnm$|\\.o$|\\.so$|\\.rdb$|\\.rdx$|\\.woff2$|\\.woff$|\\.otf$|\\.ttf$|\\.eot$|\\.docx$|\\.xlsx$|\\.pptx$|\\.xltx$|\\.potx$|\\.doc$|\\.xls$|\\.ppt$|\\.odt$|\\.ods$|\\.odp$|\\.odg$|\\.odc$|\\.odf$|\\.odi$|\\.odm$|\\.odb$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$|\\.zip$|\\.tar$|\\.gz$|\\.tgz$|\\.bz2$|\\.7z$|\\.xz$|\\.sqlite$|\\.sqlite3$|\\.pyc$|\\.jar$|\\.mo$|\\.shx$|\\.shp$|\\.laz$|\\.sbx$|\\.sbn$|\\.nc$|\\.gpkg$|\\.bam$|\\.bai$|\\.wav$|\\.mp3$|\\.mid$|\\.ogg$|\\.au$|\\.m4a$|\\.mp4$|\\.avi$|\\.mov$|\\.mkv$|\\.webm$",
           format = "binary",
           recursive = TRUE,
           ignore_case = TRUE,
@@ -287,7 +287,7 @@ testthat::test_that("file_default() creates the correct 'file_spec' objects", {
       if (!is_root_core & is_file_spec_type(
         fs_source = fs,
         path = "",
-        pattern = "^DESCRIPTION$|^NAMESPACE$|^README$|^README\\.md$|^NEWS$|^NEWS\\.md$|^LICENSE$|\\.Rbuildignore$",
+        pattern = "^DESCRIPTION$|^NAMESPACE$|^README$|^README\\.Rmd$|^README\\.md$|^NEWS$|^NEWS\\.md$|^LICENSE$|^LICENCE$|^LICENSE\\.note$|^LICENCE\\.note$|\\.Rbuildignore$|\\.Rinstignore$|^configure$|^configure\\.win$|^configure\\.ac$|^configure\\.in$|^cleanup$|^cleanup\\.win$",
         format = "text",
         recursive = FALSE,
         ignore_case = FALSE,
@@ -299,7 +299,7 @@ testthat::test_that("file_default() creates the correct 'file_spec' objects", {
       else if (!is_spec_code & is_file_spec_type(
         fs_source = fs,
         path = "R/",
-        pattern = "\\.R$|\\.r$|\\.s$",
+        pattern = "\\.R$|\\.r$|\\.s$|\\.q$",
         format = "text",
         recursive = FALSE,
         ignore_case = TRUE,
@@ -363,7 +363,7 @@ testthat::test_that("file_default() creates the correct 'file_spec' objects", {
       (!is_src & is_file_spec_type(
           fs_source = fs,
           path = "src/",
-          pattern = "\\.c$|\\.h$|\\.cpp$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$",
+          pattern = "\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$",
           format = "text",
           recursive = TRUE,
           ignore_case = TRUE,
@@ -376,7 +376,7 @@ testthat::test_that("file_default() creates the correct 'file_spec' objects", {
       else if (!is_spec_text & is_file_spec_type(
         fs_source = fs,
         path = "vignettes/",
-        pattern = "\\.R$|\\.r$|\\.s$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.Rmd$|\\.md$|\\.Rnw$|\\.tex$|\\.bib$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.csv$|\\.tsv$|\\.txt$|\\.html$|\\.css$|\\.js$|\\.xml$|\\.rtf$",
+        pattern = "\\.R$|\\.r$|\\.s$|\\.q$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.Rmd$|\\.md$|\\.csl$|\\.Rnw$|\\.tex$|\\.ltx$|\\.rsp$|\\.cls$|\\.sty$|\\.bib$|\\.bst$|\\.asis$|\\.el$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.note$|\\.csv$|\\.tsv$|\\.txt$|\\.html$|\\.htm$|\\.shtml$|\\.css$|\\.js$|\\.json$|\\.xml$|\\.scss$|\\.less$|\\.rtf$|\\.save$|\\.Rout$|\\.stan$|\\.bug$|\\.jags$|\\.py$|\\.ipynb$|\\.sh$|\\.java$|\\.bat$|\\.m4$|\\.cmake$|\\.sql$|\\.lua$|\\.rs$|\\.jl$|\\.pl$|\\.pm$|\\.po$|\\.pot$|\\.geojson$|\\.kml$|\\.prj$|\\.cpg$|\\.qpj$|\\.fasta$|\\.fastq$|\\.vcf$|\\.ped$|\\.bim$|\\.fam$|\\.gff$|\\.gtf$",
         format = "text",
         recursive = TRUE,
         ignore_case = TRUE,
@@ -389,7 +389,7 @@ testthat::test_that("file_default() creates the correct 'file_spec' objects", {
       (!is_spec_binary & is_file_spec_type(
           fs_source = fs,
           path = "vignettes/",
-          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tiff$|\\.emf$|\\.ico$|\\.webp$|\\.eps$|\\.o$|\\.so$|\\.docx$|\\.xlsx$|\\.pptx$|\\.doc$|\\.xls$|\\.ppt$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$",
+          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tif$|\\.tiff$|\\.emf$|\\.svgz$|\\.ico$|\\.webp$|\\.eps$|\\.ppm$|\\.pgm$|\\.pbm$|\\.pnm$|\\.o$|\\.so$|\\.rdb$|\\.rdx$|\\.woff2$|\\.woff$|\\.otf$|\\.ttf$|\\.eot$|\\.docx$|\\.xlsx$|\\.pptx$|\\.xltx$|\\.potx$|\\.doc$|\\.xls$|\\.ppt$|\\.odt$|\\.ods$|\\.odp$|\\.odg$|\\.odc$|\\.odf$|\\.odi$|\\.odm$|\\.odb$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$|\\.zip$|\\.tar$|\\.gz$|\\.tgz$|\\.bz2$|\\.7z$|\\.xz$|\\.sqlite$|\\.sqlite3$|\\.pyc$|\\.jar$|\\.mo$|\\.shx$|\\.shp$|\\.laz$|\\.sbx$|\\.sbn$|\\.nc$|\\.gpkg$|\\.bam$|\\.bai$|\\.wav$|\\.mp3$|\\.mid$|\\.ogg$|\\.au$|\\.m4a$|\\.mp4$|\\.avi$|\\.mov$|\\.mkv$|\\.webm$",
           format = "binary",
           recursive = TRUE,
           ignore_case = TRUE,
@@ -449,7 +449,7 @@ testthat::test_that("file_ectd() creates the correct 'file_spec' objects", {
       if (!is_root_core & is_file_spec_type(
         fs_source = fs,
         path = "",
-        pattern = "^DESCRIPTION$|^NAMESPACE$|^README$|^README\\.md$|^NEWS$|^NEWS\\.md$|^LICENSE$|\\.Rbuildignore$",
+        pattern = "^DESCRIPTION$|^NAMESPACE$|^README$|^README\\.Rmd$|^README\\.md$|^NEWS$|^NEWS\\.md$|^LICENSE$|^LICENCE$|^LICENSE\\.note$|^LICENCE\\.note$|\\.Rbuildignore$|\\.Rinstignore$|^configure$|^configure\\.win$|^configure\\.ac$|^configure\\.in$|^cleanup$|^cleanup\\.win$",
         format = "text",
         recursive = FALSE,
         ignore_case = FALSE,
@@ -461,7 +461,7 @@ testthat::test_that("file_ectd() creates the correct 'file_spec' objects", {
       else if (!is_spec_code & is_file_spec_type(
         fs_source = fs,
         path = "R/",
-        pattern = "\\.R$|\\.r$|\\.s$",
+        pattern = "\\.R$|\\.r$|\\.s$|\\.q$",
         format = "text",
         recursive = FALSE,
         ignore_case = TRUE,
@@ -525,7 +525,7 @@ testthat::test_that("file_ectd() creates the correct 'file_spec' objects", {
       (!is_src & is_file_spec_type(
           fs_source = fs,
           path = "src/",
-          pattern = "\\.c$|\\.h$|\\.cpp$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$",
+          pattern = "\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$",
           format = "text",
           recursive = TRUE,
           ignore_case = TRUE,
@@ -573,7 +573,7 @@ testthat::test_that("file_auto() creates the correct 'file_spec' objects", {
       if (!is_spec_text & is_file_spec_type(
         fs_source = fs,
         path = "inst/",
-        pattern = "\\.R$|\\.r$|\\.s$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.Rmd$|\\.md$|\\.Rnw$|\\.tex$|\\.bib$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.csv$|\\.tsv$|\\.txt$|\\.html$|\\.css$|\\.js$|\\.xml$|\\.rtf$",
+        pattern = "\\.R$|\\.r$|\\.s$|\\.q$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.Rmd$|\\.md$|\\.csl$|\\.Rnw$|\\.tex$|\\.ltx$|\\.rsp$|\\.cls$|\\.sty$|\\.bib$|\\.bst$|\\.asis$|\\.el$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.note$|\\.csv$|\\.tsv$|\\.txt$|\\.html$|\\.htm$|\\.shtml$|\\.css$|\\.js$|\\.json$|\\.xml$|\\.scss$|\\.less$|\\.rtf$|\\.save$|\\.Rout$|\\.stan$|\\.bug$|\\.jags$|\\.py$|\\.ipynb$|\\.sh$|\\.java$|\\.bat$|\\.m4$|\\.cmake$|\\.sql$|\\.lua$|\\.rs$|\\.jl$|\\.pl$|\\.pm$|\\.po$|\\.pot$|\\.geojson$|\\.kml$|\\.prj$|\\.cpg$|\\.qpj$|\\.fasta$|\\.fastq$|\\.vcf$|\\.ped$|\\.bim$|\\.fam$|\\.gff$|\\.gtf$",
         format = "text",
         recursive = TRUE,
         ignore_case = TRUE,
@@ -586,7 +586,7 @@ testthat::test_that("file_auto() creates the correct 'file_spec' objects", {
       (!is_spec_binary & is_file_spec_type(
           fs_source = fs,
           path = "inst/",
-          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tiff$|\\.emf$|\\.ico$|\\.webp$|\\.eps$|\\.o$|\\.so$|\\.docx$|\\.xlsx$|\\.pptx$|\\.doc$|\\.xls$|\\.ppt$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$",
+          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tif$|\\.tiff$|\\.emf$|\\.svgz$|\\.ico$|\\.webp$|\\.eps$|\\.ppm$|\\.pgm$|\\.pbm$|\\.pnm$|\\.o$|\\.so$|\\.rdb$|\\.rdx$|\\.woff2$|\\.woff$|\\.otf$|\\.ttf$|\\.eot$|\\.docx$|\\.xlsx$|\\.pptx$|\\.xltx$|\\.potx$|\\.doc$|\\.xls$|\\.ppt$|\\.odt$|\\.ods$|\\.odp$|\\.odg$|\\.odc$|\\.odf$|\\.odi$|\\.odm$|\\.odb$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$|\\.zip$|\\.tar$|\\.gz$|\\.tgz$|\\.bz2$|\\.7z$|\\.xz$|\\.sqlite$|\\.sqlite3$|\\.pyc$|\\.jar$|\\.mo$|\\.shx$|\\.shp$|\\.laz$|\\.sbx$|\\.sbn$|\\.nc$|\\.gpkg$|\\.bam$|\\.bai$|\\.wav$|\\.mp3$|\\.mid$|\\.ogg$|\\.au$|\\.m4a$|\\.mp4$|\\.avi$|\\.mov$|\\.mkv$|\\.webm$",
           format = "binary",
           recursive = TRUE,
           ignore_case = TRUE,


### PR DESCRIPTION
This PR extends the file extension dictionary to include commonly used files with extensions like `.stan` thus fixes #20 .

## Impact

Now you should be able to use the regular `collate(..., file_auto("inst/"))` and `collate(..., file_root_core())` calls and see the `.stan` files and configuration files defined by [use_rstan()](https://mc-stan.org/rstantools/reference/use_rstan.html) collated and tagged as text files.

## Metrics

I calculated the coverage percentage by number of files in all source packages on CRAN ([data](https://github.com/nanxstats/cran-file-exts)):

```r
x <- readLines("exts.txt")
x <- tolower(unlist(strsplit(x, split = "\t")))
y <- sort(table(x), decreasing = TRUE)
eoi <- y

df <- data.frame(
  "ext" = names(eoi),
  "mime" = mime::guess_type(paste0(".", names(eoi))),
  "count" = as.vector(eoi)
)

ext_pkglite <- unique(tolower(c(pkglite::ext_text(flat = TRUE), pkglite::ext_binary(flat = TRUE))))
ext_pkglite <- ext_pkglite[!is.na(match(ext_pkglite, df$ext))]

sum(df[match(ext_pkglite, df$ext), "count"]) / sum(df$count)
```

Before patch: 88.85%. After patch: 96.65%.

## Next step

A more fundamental fix for such issues is separating file capture rules and file type tagging rules, to make the former NOT file extension-based and much more generic (via updating the current file spec definitions), and the latter universal (via dictionary + tagging all unknown extensions as binary). This will be done in issue https://github.com/Merck/pkglite/issues/18.