### PR TITLE
Move test file scope logic into `helper.R`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,4 +30,4 @@ Suggests:
     testthat,
     covr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,108 @@
+# Locate example package path
+find_package <- function(pkg) {
+  system.file(file.path("examples", pkg), package = "pkglite")
+}
+
+# List files under a folder in an example package
+find_files <- function(pkg, dir, pattern) {
+  pkg_path <- find_package(pkg)
+  d <- file.path(paste(pkg_path, dir, sep = "/")) %>%
+    list.files(
+      pattern = pattern,
+      ignore.case = TRUE,
+      full.names = TRUE
+    ) %>%
+    gsub(pattern = paste0(".*", pkg, "/{1}"), replacement = "") %>%
+    as.data.frame(stringsAsFactors = FALSE)
+  names(d)[1] <- "files"
+  d
+}
+
+# Check if `file_spec()` returns the right object
+file_spec_func_valid <- function() {
+  path <- "R/"
+  pattern <- "\\.R$"
+  format <- "text"
+  recursive <- FALSE
+  ignore_case <- TRUE
+  all_files <- FALSE
+
+  fs_source <- file_spec(
+    path = path, pattern = pattern, format = format,
+    recursive = recursive, ignore_case = ignore_case, all_files = all_files
+  )
+
+  return(
+    fs_source$path == path &
+      fs_source$pattern == pattern &
+      fs_source$format == format &
+      fs_source$recursive == recursive &
+      fs_source$ignore_case == ignore_case &
+      fs_source$all_files == all_files &
+      class(fs_source) == "file_spec"
+  )
+}
+
+# Flatten the structure of a `file_spec` list
+fs_unlist <- function(fs) {
+  fs_len <- length(fs)
+  ls <- list()
+  ls_cnt <- 0
+
+  if (fs_len) {
+    for (i in seq_len(fs_len)) {
+      x <- fs[[i]]
+      if (class(x) == "file_spec") {
+        ls_cnt <- ls_cnt + 1
+        ls[[ls_cnt]] <- x
+      } else if (class(x) == "list") {
+        ls_tmp <- fs_unlist(x)
+        for (j in seq_len(length(ls_tmp))) {
+          ls_cnt <- ls_cnt + 1
+          ls[[ls_cnt]] <- ls_tmp[[j]]
+        }
+      }
+    }
+  }
+  ls
+}
+
+# Check if a `file_spec` object has all of the parameters as specified
+is_file_spec_type <- function(fs_source, path, pattern, format, recursive, ignore_case, all_files) {
+  return(fs_source$path == path &
+    fs_source$pattern == pattern &
+    fs_source$format == format &
+    fs_source$recursive == recursive &
+    fs_source$ignore_case == ignore_case &
+    fs_source$all_files == all_files &
+    class(fs_source) == "file_spec")
+}
+
+# Save string to a `.txt` file
+save_txt <- function(code, path = tempfile(fileext = ".txt")) {
+  writeLines(code, con = path)
+  path
+}
+
+# Create artifacts for testing `pack()`
+create_artifacts_pack <- function() {
+  pkg1 <- system.file("examples/pkg1", package = "pkglite")
+  pkg2 <- system.file("examples/pkg2", package = "pkglite")
+  fc1 <- pkg1 %>% collate(file_default())
+  fc2 <- pkg2 %>% collate(file_default())
+  txt <- tempfile(fileext = ".txt")
+
+  list("pkg1" = pkg1, "pkg2" = pkg2, "fc1" = fc1, "fc2" = fc2, "txt" = txt)
+}
+
+# Create artifacts for testing `unpack()`
+create_artifacts_unpack <- function() {
+  pkg1 <- "pkg1" %>% find_package()
+  pkg2 <- "pkg2" %>% find_package()
+  fc1 <- pkg1 %>% collate(file_r())
+  fc2 <- pkg2 %>% collate(file_r())
+  txt <- tempfile(fileext = ".txt")
+  pack(fc1, fc2, output = txt, quiet = TRUE)
+
+  list("pkg1" = pkg1, "pkg2" = pkg2, "fc1" = fc1, "fc2" = fc2, "txt" = txt)
+}

--- a/tests/testthat/test-independent-test_file_spec.R
+++ b/tests/testthat/test-independent-test_file_spec.R
@@ -1,4 +1,4 @@
-testthat::test_that("file_spec() creates the correct 'file_spec' object", {
+test_that("file_spec() creates the correct 'file_spec' object", {
   path <- "R/"
   pattern <- "\\.R$"
   format <- "text"
@@ -11,17 +11,17 @@ testthat::test_that("file_spec() creates the correct 'file_spec' object", {
     recursive = recursive, ignore_case = ignore_case, all_files = all_files
   )
 
-  testthat::expect_equal(fs_source$path, path)
-  testthat::expect_equal(fs_source$pattern, pattern)
-  testthat::expect_equal(fs_source$format, format)
-  testthat::expect_equal(fs_source$recursive, recursive)
-  testthat::expect_equal(fs_source$ignore_case, ignore_case)
-  testthat::expect_equal(fs_source$all_files, all_files)
-  testthat::expect_equal(class(fs_source), "file_spec")
-  testthat::expect_error(file_spec(), "Must provide a non-empty `path`.")
+  expect_equal(fs_source$path, path)
+  expect_equal(fs_source$pattern, pattern)
+  expect_equal(fs_source$format, format)
+  expect_equal(fs_source$recursive, recursive)
+  expect_equal(fs_source$ignore_case, ignore_case)
+  expect_equal(fs_source$all_files, all_files)
+  expect_equal(class(fs_source), "file_spec")
+  expect_error(file_spec(), "Must provide a non-empty `path`.")
 })
 
-testthat::test_that("is_file_spec() checks the presence of 'file_spec' as the class specifier", {
+test_that("is_file_spec() checks the presence of 'file_spec' as the class specifier", {
   path <- "R/"
   pattern <- "\\.R$"
   format <- "text"
@@ -37,12 +37,12 @@ testthat::test_that("is_file_spec() checks the presence of 'file_spec' as the cl
   dummy <- 1
   class(dummy) <- "file"
 
-  testthat::expect_equal(is_file_spec(fs_source), TRUE)
-  testthat::expect_equal(is_file_spec(dummy), FALSE)
+  expect_equal(is_file_spec(fs_source), TRUE)
+  expect_equal(is_file_spec(dummy), FALSE)
 })
 
 
-testthat::test_that("Check print.file_spec() is returning the right file_spec() object", {
+test_that("Check print.file_spec() is returning the right file_spec() object", {
   path <- "R/"
   pattern <- "\\.R$"
   format <- "text"
@@ -57,5 +57,5 @@ testthat::test_that("Check print.file_spec() is returning the right file_spec() 
 
   x <- print.file_spec(fs_source)
 
-  testthat::expect_equal(x, fs_source)
+  expect_equal(x, fs_source)
 })

--- a/tests/testthat/test-independent-test_templates.R
+++ b/tests/testthat/test-independent-test_templates.R
@@ -1,64 +1,4 @@
-# check if the file_spec() is returning the right object
-file_spec_func_valid <- function() {
-  path <- "R/"
-  pattern <- "\\.R$"
-  format <- "text"
-  recursive <- FALSE
-  ignore_case <- TRUE
-  all_files <- FALSE
-
-  fs_source <- file_spec(
-    path = path, pattern = pattern, format = format,
-    recursive = recursive, ignore_case = ignore_case, all_files = all_files
-  )
-
-  return(
-    fs_source$path == path &
-      fs_source$pattern == pattern &
-      fs_source$format == format &
-      fs_source$recursive == recursive &
-      fs_source$ignore_case == ignore_case &
-      fs_source$all_files == all_files &
-      class(fs_source) == "file_spec"
-  )
-}
-
-# flatten the structure of a file_spec list
-fs_unlist <- function(fs) {
-  fs_len <- length(fs)
-  ls <- list()
-  ls_cnt <- 0
-
-  if (fs_len) {
-    for (i in seq_len(fs_len)) {
-      x <- fs[[i]]
-      if (class(x) == "file_spec") {
-        ls_cnt <- ls_cnt + 1
-        ls[[ls_cnt]] <- x
-      } else if (class(x) == "list") {
-        ls_tmp <- fs_unlist(x)
-        for (j in seq_len(length(ls_tmp))) {
-          ls_cnt <- ls_cnt + 1
-          ls[[ls_cnt]] <- ls_tmp[[j]]
-        }
-      }
-    }
-  }
-  ls
-}
-
-# check if a file_spec object has all of the parameters as specified
-is_file_spec_type <- function(fs_source, path, pattern, format, recursive, ignore_case, all_files) {
-  return(fs_source$path == path &
-    fs_source$pattern == pattern &
-    fs_source$format == format &
-    fs_source$recursive == recursive &
-    fs_source$ignore_case == ignore_case &
-    fs_source$all_files == all_files &
-    class(fs_source) == "file_spec")
-}
-
-testthat::test_that("file_root_core() creates the correct 'file_spec' object", {
+test_that("file_root_core() creates the correct 'file_spec' object", {
   is_root_core <- is_file_spec_type(
     fs_source = file_root_core(),
     path = "",
@@ -69,11 +9,10 @@ testthat::test_that("file_root_core() creates the correct 'file_spec' object", {
     all_files = TRUE
   )
 
-  testthat::expect_equal(is_root_core, TRUE)
+  expect_equal(is_root_core, TRUE)
 })
 
-
-testthat::test_that("file_root_all() creates the correct 'file_spec' object", {
+test_that("file_root_all() creates the correct 'file_spec' object", {
   is_root_all <- is_file_spec_type(
     fs_source = file_root_all(),
     path = "",
@@ -84,11 +23,10 @@ testthat::test_that("file_root_all() creates the correct 'file_spec' object", {
     all_files = TRUE
   )
 
-  testthat::expect_equal(is_root_all, TRUE)
+  expect_equal(is_root_all, TRUE)
 })
 
-
-testthat::test_that("file_r() creates the correct 'file_spec' objects", {
+test_that("file_r() creates the correct 'file_spec' objects", {
   fs_source <- file_r()
   is_spec_code <- FALSE
   is_spec_data <- FALSE
@@ -125,12 +63,11 @@ testthat::test_that("file_r() creates the correct 'file_spec' objects", {
     }
   }
 
-  testthat::expect_equal(is_spec_code, TRUE)
-  testthat::expect_equal(is_spec_data, TRUE)
+  expect_equal(is_spec_code, TRUE)
+  expect_equal(is_spec_data, TRUE)
 })
 
-
-testthat::test_that("file_man() creates the correct 'file_spec' objects", {
+test_that("file_man() creates the correct 'file_spec' objects", {
   fs_source <- file_man()
 
   is_spec_rd <- FALSE
@@ -181,13 +118,12 @@ testthat::test_that("file_man() creates the correct 'file_spec' objects", {
     }
   }
 
-  testthat::expect_equal(is_spec_rd, TRUE)
-  testthat::expect_equal(is_spec_fig_binary, TRUE)
-  testthat::expect_equal(is_spec_fig_text, TRUE)
+  expect_equal(is_spec_rd, TRUE)
+  expect_equal(is_spec_fig_binary, TRUE)
+  expect_equal(is_spec_fig_text, TRUE)
 })
 
-
-testthat::test_that("file_src() creates the correct 'file_spec' object", {
+test_that("file_src() creates the correct 'file_spec' object", {
   is_src <- is_file_spec_type(
     fs_source = file_src(),
     path = "src/",
@@ -198,11 +134,10 @@ testthat::test_that("file_src() creates the correct 'file_spec' object", {
     all_files = FALSE
   )
 
-  testthat::expect_equal(is_src, TRUE)
+  expect_equal(is_src, TRUE)
 })
 
-
-testthat::test_that("file_data() creates the correct 'file_spec' object", {
+test_that("file_data() creates the correct 'file_spec' object", {
   is_data <- is_file_spec_type(
     fs_source = file_data(),
     path = "data/",
@@ -213,11 +148,10 @@ testthat::test_that("file_data() creates the correct 'file_spec' object", {
     all_files = FALSE
   )
 
-  testthat::expect_equal(is_data, TRUE)
+  expect_equal(is_data, TRUE)
 })
 
-
-testthat::test_that("file_vignettes() creates the correct 'file_spec' objects", {
+test_that("file_vignettes() creates the correct 'file_spec' objects", {
   fs_source <- file_vignettes()
   is_spec_text <- FALSE
   is_spec_binary <- FALSE
@@ -254,12 +188,11 @@ testthat::test_that("file_vignettes() creates the correct 'file_spec' objects", 
     }
   }
 
-  testthat::expect_equal(is_spec_text, TRUE)
-  testthat::expect_equal(is_spec_binary, TRUE)
+  expect_equal(is_spec_text, TRUE)
+  expect_equal(is_spec_binary, TRUE)
 })
 
-
-testthat::test_that("file_default() creates the correct 'file_spec' objects", {
+test_that("file_default() creates the correct 'file_spec' objects", {
   fs_source <- file_default()
   # linearize the file_spec list
   fs_ls <- fs_unlist(fs_source)
@@ -400,20 +333,20 @@ testthat::test_that("file_default() creates the correct 'file_spec' objects", {
   }
 
 
-  testthat::expect_equal(is_root_core, TRUE)
-  testthat::expect_equal(is_spec_code, TRUE)
-  testthat::expect_equal(is_spec_data, TRUE)
-  testthat::expect_equal(is_spec_rd, TRUE)
-  testthat::expect_equal(is_spec_fig_binary, TRUE)
-  testthat::expect_equal(is_spec_fig_text, TRUE)
-  testthat::expect_equal(is_src, TRUE)
-  testthat::expect_equal(is_spec_text, TRUE)
-  testthat::expect_equal(is_spec_binary, TRUE)
-  testthat::expect_equal(is_data, TRUE)
+  expect_equal(is_root_core, TRUE)
+  expect_equal(is_spec_code, TRUE)
+  expect_equal(is_spec_data, TRUE)
+  expect_equal(is_spec_rd, TRUE)
+  expect_equal(is_spec_fig_binary, TRUE)
+  expect_equal(is_spec_fig_text, TRUE)
+  expect_equal(is_src, TRUE)
+  expect_equal(is_spec_text, TRUE)
+  expect_equal(is_spec_binary, TRUE)
+  expect_equal(is_data, TRUE)
 })
 
 
-testthat::test_that("file_ectd() creates the correct 'file_spec' objects", {
+test_that("file_ectd() creates the correct 'file_spec' objects", {
   fs_source <- file_ectd()
   # linearize the file_spec list
   fs_ls <- fs_unlist(fs_source)
@@ -528,17 +461,17 @@ testthat::test_that("file_ectd() creates the correct 'file_spec' objects", {
     }
   }
 
-  testthat::expect_equal(is_root_core, TRUE)
-  testthat::expect_equal(is_spec_code, TRUE)
-  testthat::expect_equal(is_spec_data, TRUE)
-  testthat::expect_equal(is_spec_rd, TRUE)
-  testthat::expect_equal(is_spec_fig_binary, TRUE)
-  testthat::expect_equal(is_spec_fig_text, TRUE)
-  testthat::expect_equal(is_src, TRUE)
-  testthat::expect_equal(is_data, TRUE)
+  expect_equal(is_root_core, TRUE)
+  expect_equal(is_spec_code, TRUE)
+  expect_equal(is_spec_data, TRUE)
+  expect_equal(is_spec_rd, TRUE)
+  expect_equal(is_spec_fig_binary, TRUE)
+  expect_equal(is_spec_fig_text, TRUE)
+  expect_equal(is_src, TRUE)
+  expect_equal(is_data, TRUE)
 })
 
-testthat::test_that("file_auto() creates the correct 'file_spec' objects", {
+test_that("file_auto() creates the correct 'file_spec' objects", {
   fs_source <- file_auto("inst/")
   is_spec_text <- FALSE
   is_spec_binary <- FALSE
@@ -575,22 +508,22 @@ testthat::test_that("file_auto() creates the correct 'file_spec' objects", {
     }
   }
 
-  testthat::expect_equal(is_spec_text, TRUE)
-  testthat::expect_equal(is_spec_binary, TRUE)
+  expect_equal(is_spec_text, TRUE)
+  expect_equal(is_spec_binary, TRUE)
 })
 
-testthat::test_that("cat_patterns() generate the right string pattern", {
+test_that("cat_patterns() generate the right string pattern", {
   str <- c("x", "y", "z")
   str_target <- "x|y|z"
   str_source <- cat_patterns(str)
 
-  testthat::expect_equal(str_source, str_target)
+  expect_equal(str_source, str_target)
 })
 
-testthat::test_that("ends_with() generate the right string pattern", {
+test_that("ends_with() generate the right string pattern", {
   str <- c("x", "y", "z")
   str_target <- c("\\.x$", "\\.y$", "\\.z$")
   str_source <- ends_with(str)
 
-  testthat::expect_equal(str_source, str_target)
+  expect_equal(str_source, str_target)
 })

--- a/tests/testthat/test-independent-test_utils.R
+++ b/tests/testthat/test-independent-test_utils.R
@@ -1,5 +1,5 @@
 test_that("verify_ascii() should check if all texts in file are printable", {
-  # test binary
+  # Test binary
   out_bin <- c(
     "fa\xE7ile test of showNonASCII():",
     "\\details{",
@@ -11,7 +11,7 @@ test_that("verify_ascii() should check if all texts in file are printable", {
   f_bin <- tempfile()
   cat(out_bin, file = f_bin, sep = "\n")
 
-  # test text
+  # Test text
   out_txt <- c(
     "Just simple texts",
     "very simple :)",
@@ -52,9 +52,9 @@ test_that("remove_content() removing specified target line (must be indented by 
   t_ln_cleaned <- as.logical(sum(!is.na(match(cleaned, target_ln))))
   t_str_cleaned <- as.logical(sum(!is.na(match(cleaned, target_str))))
 
-  # non-content target kept?
+  # Non-content target kept?
   expect_equal(t_str_cleaned, TRUE)
-  # content targets kept ?
+  # Content targets kept ?
   expect_equal(t_ln_cleaned, FALSE)
 
   unlink(f_txt)

--- a/tests/testthat/test-independent-test_utils_cli.R
+++ b/tests/testthat/test-independent-test_utils_cli.R
@@ -1,76 +1,66 @@
-# test cli_text
-testthat::test_that("cli_text prints concatenated texts with \n as separator", {
+test_that("cli_text prints concatenated texts with \n as separator", {
   strs <- c("str1", "str2", "str999")
   cli_text(strs)
-  testthat::expect_output(cli_text(strs), regexp = "str1\\nstr2\\nstr999")
+  expect_output(cli_text(strs), regexp = "str1\\nstr2\\nstr999")
 })
 
-# test cli_h1
-testthat::test_that("cli_h1 prints string as header with prefix and suffix", {
+test_that("cli_h1 prints string as header with prefix and suffix", {
   strs <- "This is a test heading"
   strl <- "This is a really longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg heading"
   cli_h1(strs)
   cli_h1(strl)
-  testthat::expect_output(cli_h1(strs), regexp = ".*?This is a test heading.*?\\-+.*")
-  testthat::expect_output(cli_h1(strl), regexp = ".*?This is a really long+ heading.*?\\-*")
+  expect_output(cli_h1(strs), regexp = ".*?This is a test heading.*?\\-+.*")
+  expect_output(cli_h1(strl), regexp = ".*?This is a really long+ heading.*?\\-*")
 })
 
-# test cli_rule
-testthat::test_that("cli_rule combines strings and prints as header with prefix and suffix", {
+test_that("cli_rule combines strings and prints as header with prefix and suffix", {
   strs <- "This is a test heading "
   strs2 <- "plus other things"
-  strl <- "This is a heading with some special sympols like *,;%#$."
+  strl <- "This is a heading with some special symbols like *,;%#$."
   strs3 <- ""
   cli_rule(strs, strs2)
   cli_rule(strl, strs2)
-  testthat::expect_output(cli_rule(strs, strs2), regexp = "\\-\\- This is a test heading plus other things \\-+")
-  testthat::expect_output(cli_rule(strl, strs2), regexp = "\\-\\- This is a heading with some special sympols like \\*,;%#\\$\\.plus other things \\-+")
+  expect_output(cli_rule(strs, strs2), regexp = "\\-\\- This is a test heading plus other things \\-+")
+  expect_output(cli_rule(strl, strs2), regexp = "\\-\\- This is a heading with some special symbols like \\*,;%#\\$\\.plus other things \\-+")
 })
 
-# test cli_li
-testthat::test_that("cli_li prints string with a leading bullet point", {
+test_that("cli_li prints string with a leading bullet point", {
   strs <- "This is a test heading "
   strs2 <- "plus other things"
   cli_li(strs, strs2)
-  testthat::expect_output(cli_li(strs, strs2), regexp = "- This is a test heading plus other things")
+  expect_output(cli_li(strs, strs2), regexp = "- This is a test heading plus other things")
 })
 
-# test cli_str
-testthat::test_that("cli_str create strings with double quotation in blue when printed in console", {
+test_that("cli_str create strings with double quotation in blue when printed in console", {
   strs <- "This is a test string"
-  testthat::expect_equal(cli_str(strs), crayon::blue(paste0('"', strs, '"')))
+  expect_equal(cli_str(strs), crayon::blue(paste0('"', strs, '"')))
 })
 
-# test cli_bool
-testthat::test_that("cli_bool creates boolean object in blue color", {
+test_that("cli_bool creates boolean object in blue color", {
   strs <- TRUE
-  testthat::expect_equal(cli_bool(strs), crayon::blue(strs))
+  expect_equal(cli_bool(strs), crayon::blue(strs))
 })
 
-# test cli_num
-testthat::test_that("cli_num output string as header with prefix and suffix", {
+test_that("cli_num output string as header with prefix and suffix", {
   nums <- 123
-  testthat::expect_equal(cli_num(nums), crayon::green(nums))
+  expect_equal(cli_num(nums), crayon::green(nums))
 })
 
-# test cli_pkg
-testthat::test_that("cli_pkg creates package name in blue", {
+test_that("cli_pkg creates package name in blue", {
   strs <- "test_pkg_name_in_blue"
-  testthat::expect_equal(cli_pkg(strs), crayon::blue(strs))
+  expect_equal(cli_pkg(strs), crayon::blue(strs))
 })
 
-# test cli_path_src
-testthat::test_that("cli_path_src output string in green with double quotations surrounded", {
+test_that("cli_path_src output string in green with double quotations surrounded", {
   fd1 <- "/opt"
   fd2 <- "folder"
   fd3 <- "another-folder"
-  testthat::expect_equal(cli_path_src(fd1, fd2, fd3), crayon::green('"/opt/folder/another-folder"'))
+  expect_equal(cli_path_src(fd1, fd2, fd3), crayon::green('"/opt/folder/another-folder"'))
 })
 
-# test cli_path_dst
-testthat::test_that("cli_path_dst output string in blue with double quotations surrounded", {
+test_that("cli_path_dst output string in blue with double quotations surrounded", {
   fd1 <- "/opt"
   fd2 <- "folder"
   fd3 <- "another-folder"
-  testthat::expect_equal(cli_path_dst(fd1, fd2, fd3), crayon::blue('"/opt/folder/another-folder"'))
+  expect_equal(cli_path_dst(fd1, fd2, fd3), crayon::blue('"/opt/folder/another-folder"'))
 })

--- a/tests/testthat/test-independent_test_collate.R
+++ b/tests/testthat/test-independent_test_collate.R
@@ -1,32 +1,12 @@
-# locate example package path
-find_package <- function(pkg) {
-  system.file(paste0("examples/", pkg), package = "pkglite")
-}
-
-# list files under a folder in an example package
-find_files <- function(pkg, dir, pattern) {
-  pkg_path <- find_package(pkg)
-  d <- file.path(paste(pkg_path, dir, sep = "/")) %>%
-    list.files(
-      pattern = pattern,
-      ignore.case = TRUE,
-      full.names = TRUE
-    ) %>%
-    gsub(pattern = paste0(".*", pkg, "/{1}"), replacement = "") %>%
-    as.data.frame(stringsAsFactors = FALSE)
-  names(d)[1] <- "files"
-  d
-}
-
-testthat::test_that("collate returns the package name correctly", {
+test_that("collate returns the package name correctly", {
   pkg <- "pkg1"
   actual <- pkg %>%
     find_package() %>%
     collate(file_default())
-  testthat::expect_equal(pkg, actual$pkg_name)
+  expect_equal(pkg, actual$pkg_name)
 })
 
-testthat::test_that("collate returns the full path correctly", {
+test_that("collate returns the full path correctly", {
   pkg <- "pkg1"
   files <- pkg %>%
     find_package() %>%
@@ -45,58 +25,58 @@ testthat::test_that("collate returns the full path correctly", {
   expected <- path %>%
     gsub(pattern = paste0(pkg, ".*", "{1}"), replacement = "") %>%
     unique()
-  testthat::expect_equal(actual, expected)
+  expect_equal(actual, expected)
 })
 
-testthat::test_that("collate returns the files names in the R directory correctly", {
+test_that("collate returns the files names in the R directory correctly", {
   pkg <- "pkg1"
   actual <- pkg %>%
     find_package() %>%
     collate(file_r())
   expected <- find_files(pkg, dir = "R", pattern = "*.R$|.rda$")
-  testthat::expect_equal(actual$df$path_rel, expected$files)
+  expect_equal(actual$df$path_rel, expected$files)
 })
 
-testthat::test_that("collate returns the help files correctly", {
+test_that("collate returns the help files correctly", {
   pkg <- "pkg1"
   files <- pkg %>%
     find_package() %>%
     collate(file_man())
   actual <- files$df %>% base::subset(format == "text")
   expected <- find_files(pkg, dir = "man", pattern = "*.Rd$")
-  testthat::expect_equal(actual$path_rel, expected$files)
+  expect_equal(actual$path_rel, expected$files)
 })
 
-testthat::test_that("collate returns error when no file spec is passed through", {
+test_that("collate returns error when no file spec is passed through", {
   pkg <- "pkg1"
-  testthat::expect_error(pkg %>% find_package() %>% collate())
+  expect_error(pkg %>% find_package() %>% collate())
 })
 
-testthat::test_that("collate returns 0-row data when the file spec is not in the right format", {
+test_that("collate returns 0-row data when the file spec is not in the right format", {
   pkg <- "pkg1"
   files <- pkg %>%
     find_package() %>%
     collate(file_src())
-  testthat::expect_equal(nrow(files$df), 0L)
+  expect_equal(nrow(files$df), 0L)
 })
 
-testthat::test_that("fs_to_df returns error when no path is passed through", {
-  testthat::expect_error(fs_to_df(file_spec = file_default()))
+test_that("fs_to_df returns error when no path is passed through", {
+  expect_error(fs_to_df(file_spec = file_default()))
 })
 
-testthat::test_that("fs_to_df returns error when no file spec is passed through", {
-  testthat::expect_error(pkg %>% find_package() %>% fs_to_df())
+test_that("fs_to_df returns error when no file spec is passed through", {
+  expect_error(pkg %>% find_package() %>% fs_to_df())
 })
 
-testthat::test_that("fs_to_df returns 0-row data when the file spec is not in the right format", {
+test_that("fs_to_df returns 0-row data when the file spec is not in the right format", {
   pkg <- "pkg1"
   files <- pkg %>%
     find_package() %>%
     fs_to_df(file_src())
-  testthat::expect_equal(nrow(files), 0L)
+  expect_equal(nrow(files), 0L)
 })
 
-testthat::test_that("fs_to_df evaluates a file spec and return the data frame correctly", {
+test_that("fs_to_df evaluates a file spec and return the data frame correctly", {
   lst <- list(
     "path" = "R/",
     "pattern" = "\\.R$",
@@ -116,18 +96,18 @@ testthat::test_that("fs_to_df evaluates a file spec and return the data frame co
     full.names = TRUE
   )
   expected <- find_files(pkg, dir = "R", pattern = "*.R$")
-  testthat::expect_equal(names(actual), c("path_abs", "path_rel", "format"))
-  testthat::expect_equal(actual$path_rel, expected$files)
-  testthat::expect_equal(actual$path_abs, expected_files)
-  testthat::expect_length(object = actual$path_abs, n = nrow(expected))
+  expect_equal(names(actual), c("path_abs", "path_rel", "format"))
+  expect_equal(actual$path_rel, expected$files)
+  expect_equal(actual$path_abs, expected_files)
+  expect_length(object = actual$path_abs, n = nrow(expected))
 })
 
-testthat::test_that("get_pkg_name returns the package name correctly", {
-  testthat::expect_equal(get_pkg_name(path = find_package("pkg1")), "pkg1")
-  testthat::expect_equal(get_pkg_name(path = find_package("pkg2")), "pkg2")
+test_that("get_pkg_name returns the package name correctly", {
+  expect_equal(get_pkg_name(path = find_package("pkg1")), "pkg1")
+  expect_equal(get_pkg_name(path = find_package("pkg2")), "pkg2")
 })
 
-testthat::test_that("create_fc_df returns the data frame correctly", {
+test_that("create_fc_df returns the data frame correctly", {
   n_row <- 3L
   expected <- data.frame(
     "path_abs" = rep(NA, n_row),
@@ -135,5 +115,5 @@ testthat::test_that("create_fc_df returns the data frame correctly", {
     "format" = rep(NA, n_row),
     stringsAsFactors = FALSE
   )
-  testthat::expect_identical(expected, create_fc_df(n_row))
+  expect_identical(expected, create_fc_df(n_row))
 })

--- a/tests/testthat/test-independent_test_collection.R
+++ b/tests/testthat/test-independent_test_collection.R
@@ -1,27 +1,7 @@
-# locate example package path
-find_package <- function(pkg) {
-  system.file(paste0("examples/", pkg), package = "pkglite")
-}
-
-# list files under a folder in an example package
-find_files <- function(pkg, dir, pattern) {
-  pkg_path <- find_package(pkg)
-  d <- file.path(paste(pkg_path, dir, sep = "/")) %>%
-    list.files(
-      pattern = pattern,
-      ignore.case = TRUE,
-      full.names = TRUE
-    ) %>%
-    gsub(pattern = paste0(".*", pkg, "/{1}"), replacement = "") %>%
-    as.data.frame(stringsAsFactors = FALSE)
-  names(d)[1] <- "files"
-  d
-}
-
-testthat::test_that("is_file_collection detects whether an object is of class
+test_that("is_file_collection detects whether an object is of class
                     file collection", {
   pkg <- "pkg1"
-  testthat::expect_false(
+  expect_false(
     pkg %>%
       find_package() %>%
       fs_to_df(file_spec = file_src()) %>%
@@ -29,7 +9,7 @@ testthat::test_that("is_file_collection detects whether an object is of class
   )
 })
 
-testthat::test_that("print returns a data frame as expected", {
+test_that("print returns a data frame as expected", {
   pkg <- "pkg1"
   actual <- pkg %>%
     find_package() %>%
@@ -42,46 +22,46 @@ testthat::test_that("print returns a data frame as expected", {
     "format" = rep("text", length(files$files)),
     stringsAsFactors = FALSE
   )
-  testthat::expect_identical(actual[, -1], expected)
+  expect_identical(actual[, -1], expected)
 })
 
-testthat::test_that("merge can merge two empty file collections and return
+test_that("merge can merge two empty file collections and return
                     an empty file collection", {
   fc1 <- new_file_collection("pkg1", df = create_fc_df(0))
   pkg <- system.file("examples/pkg1/", package = "pkglite")
   fc2 <- pkg %>% collate(file_root_core())
   fc2$df <- create_fc_df(0)
-  testthat::expect_true(merge(fc1, fc2) %>% is_file_collection())
+  expect_true(merge(fc1, fc2) %>% is_file_collection())
 })
 
-testthat::test_that("merge returns error when some inputs are not
+test_that("merge returns error when some inputs are not
                     file collection objects", {
   pkg <- system.file("examples/pkg1/", package = "pkglite")
   fc1 <- pkg %>% collate(file_root_core())
   fc2 <- c("apple", "oranges")
-  testthat::expect_error(merge(fc1, fc2))
+  expect_error(merge(fc1, fc2))
 })
 
-testthat::test_that("merge returns error when the input file collections
+test_that("merge returns error when the input file collections
                     are for different packages", {
   pkg1 <- system.file("examples/pkg1/", package = "pkglite")
   fc1 <- pkg1 %>% collate(file_root_core())
   pkg2 <- system.file("examples/pkg2/", package = "pkglite")
   fc2 <- pkg2 %>% collate(file_root_core())
-  testthat::expect_error(merge(fc1, fc2))
+  expect_error(merge(fc1, fc2))
 })
 
-testthat::test_that("merge returns a file collection with the correct
+test_that("merge returns a file collection with the correct
                     number of files when the file collections contain
                     non-duplicated relative paths", {
   pkg <- system.file("examples/pkg1/", package = "pkglite")
   fc1 <- pkg %>% collate(file_r())
   fc2 <- pkg %>% collate(file_man())
   fc_merged <- merge(fc1, fc2)
-  testthat::expect_equal(nrow(fc_merged$df), nrow(fc1$df) + nrow(fc2$df))
+  expect_equal(nrow(fc_merged$df), nrow(fc1$df) + nrow(fc2$df))
 })
 
-testthat::test_that("merge returns a file collection with the correct
+test_that("merge returns a file collection with the correct
                     number of files when the file collections contain
                     duplicated relative paths", {
   pkg <- system.file("examples/pkg1/", package = "pkglite")
@@ -89,24 +69,24 @@ testthat::test_that("merge returns a file collection with the correct
   fc2 <- pkg %>% collate(file_r(), file_root_core())
   x <- union(fc1$df$path_rel, fc2$df$path_rel)
   fc_merged <- merge(fc1, fc2)
-  testthat::expect_equal(nrow(fc_merged$df), length(x))
+  expect_equal(nrow(fc_merged$df), length(x))
 })
 
-testthat::test_that("prune returns the same file collection when no files
+test_that("prune returns the same file collection when no files
                     match the provided path", {
   fc <- system.file("examples/pkg1/", package = "pkglite") %>%
     collate(file_r())
-  testthat::expect_warning(fc %>% prune(c("NEWS.md", "man/figures/logo.png")))
+  expect_warning(fc %>% prune(c("NEWS.md", "man/figures/logo.png")))
 
   oldw <- getOption("warn")
   options(warn = -1)
   fc_new <- fc %>% prune(path = "NEWS.md")
   options(warn = oldw)
 
-  testthat::expect_equal(fc, fc_new)
+  expect_equal(fc, fc_new)
 })
 
-testthat::test_that("prune returns a file collection with the correct
+test_that("prune returns a file collection with the correct
                     number of files when some files match the provided path", {
   fc <- system.file("examples/pkg1/", package = "pkglite") %>%
     collate(file_default())
@@ -117,21 +97,21 @@ testthat::test_that("prune returns a file collection with the correct
   options(warn = oldw)
 
   x <- intersect(fc$df$path_rel, c("NEWS.md", "man/figures/logo.png", "README.rmd"))
-  testthat::expect_equal(nrow(fc$df) - length(x), nrow(fc_pruned$df))
+  expect_equal(nrow(fc$df) - length(x), nrow(fc_pruned$df))
 })
 
-testthat::test_that("prune returns an empty file collection object
+test_that("prune returns an empty file collection object
                     when all files are removed", {
   fc <- system.file("examples/pkg1/", package = "pkglite") %>%
     collate(file_root_core())
   fc_pruned <- fc %>% prune(c("DESCRIPTION", "NAMESPACE", "NEWS.md", "README.md"))
-  testthat::expect_equal(nrow(fc_pruned$df), 0)
+  expect_equal(nrow(fc_pruned$df), 0)
 })
 
-testthat::test_that("prune returns a file collection with the correct
+test_that("prune returns a file collection with the correct
                     number of rows with a warning when the provided path
                     can be partially matched", {
-  testthat::expect_warning(system.file("examples/pkg1/", package = "pkglite") %>%
+  expect_warning(system.file("examples/pkg1/", package = "pkglite") %>%
     collate(file_default()) %>%
     prune(path = c("NEWS.md", "man/figure/logo.png")))
   fc <- system.file("examples/pkg1/", package = "pkglite") %>%
@@ -140,10 +120,10 @@ testthat::test_that("prune returns a file collection with the correct
   options(warn = -1)
   fc_pruned <- fc %>% prune(c("NEWS.md", "man/figure/logo.png", "README.rmd"))
   options(warn = oldw)
-  testthat::expect_equal(nrow(fc_pruned$df), 14)
+  expect_equal(nrow(fc_pruned$df), 14)
 })
 
-testthat::test_that("sanitize can successfully remove commonly excluded
+test_that("sanitize can successfully remove commonly excluded
                     files and directories from a file collection", {
   actual <- system.file("examples/pkg1/", package = "pkglite") %>%
     collate(file_default()) %>%
@@ -165,5 +145,5 @@ testthat::test_that("sanitize can successfully remove commonly excluded
   )
   test <- actual
   test$df <- temp
-  testthat::expect_equal(sanitize(actual), sanitize(test))
+  expect_equal(sanitize(actual), sanitize(test))
 })

--- a/tests/testthat/test-independent_test_pack.R
+++ b/tests/testthat/test-independent_test_pack.R
@@ -1,70 +1,76 @@
-pkg1 <- system.file("examples/pkg1", package = "pkglite")
-pkg2 <- system.file("examples/pkg2", package = "pkglite")
-fc1 <- pkg1 %>% collate(file_default())
-fc2 <- pkg2 %>% collate(file_default())
-txt <- tempfile(fileext = ".txt")
+test_that("pack returns the text file correctly", {
+  res <- create_artifacts_pack()
+  x <- pack(res$fc1, res$fc2, output = res$txt, quiet = TRUE)
 
-save_txt <- function(code, path = tempfile(fileext = ".txt")) {
-  writeLines(code, con = path)
-  path
-}
-
-testthat::test_that("pack returns the text file correctly", {
   local_edition(3)
-  x <- pack(fc1, fc2, output = txt, quiet = TRUE)
-  testthat::expect_snapshot_file(save_txt(x %>% readLines()), "pack.txt", binary = FALSE)
+  expect_snapshot_file(save_txt(x %>% readLines()), "pack.txt")
 })
 
-testthat::test_that("get_fc_pkg returns the package name correctly", {
-  testthat::expect_equal(get_fc_pkg(list(fc1, fc2)), c("pkg1", "pkg2"))
+test_that("get_fc_pkg returns the package name correctly", {
+  res <- create_artifacts_pack()
+  expect_equal(get_fc_pkg(list(res$fc1, res$fc2)), c("pkg1", "pkg2"))
 })
 
-testthat::test_that("fc_to_text returns the strings correctly", {
+test_that("fc_to_text returns the strings correctly", {
+  res <- create_artifacts_pack()
+  lst_fc <- list(res$fc1, res$fc2)
+
   local_edition(3)
-  lst_fc <- list(fc1, fc2)
-  testthat::expect_snapshot_file(save_txt(fc_to_text(lst_fc[[1]]) %>% unlist()), "fc_to_text1.txt", binary = FALSE)
-  testthat::expect_snapshot_file(save_txt(fc_to_text(lst_fc[[2]]) %>% unlist()), "fc_to_text2.txt", binary = FALSE)
+  expect_snapshot_file(save_txt(fc_to_text(lst_fc[[1]]) %>% unlist()), "fc_to_text1.txt")
+  expect_snapshot_file(save_txt(fc_to_text(lst_fc[[2]]) %>% unlist()), "fc_to_text2.txt")
 })
 
-testthat::test_that("file_to_vec returns the strings correctly", {
-  local_edition(3)
-  fc <- list(fc1, fc2)
+test_that("file_to_vec returns the strings correctly", {
+  res <- create_artifacts_pack()
+  fc <- list(res$fc1, res$fc2)
   df <- fc[[1]][["df"]]
   pkg_name <- fc[[1]][["pkg_name"]]
   nfiles <- nrow(df)
-  res <- lapply(1:nfiles, function(i) {
-    path_rel <- df[i, "path_rel"]
-    file_to_vec(df[i, "path_abs"], format = df[i, "format"], pkg_name = pkg_name, path_rel = path_rel)
-  }) %>% unlist()
+  res <- lapply(
+    1:nfiles, function(i) {
+      path_rel <- df[i, "path_rel"]
+      file_to_vec(
+        df[i, "path_abs"],
+        format = df[i, "format"],
+        pkg_name = pkg_name,
+        path_rel = path_rel
+      )
+    }
+  ) %>% unlist()
 
-  testthat::expect_snapshot_file(save_txt(res), "file_to_vec.txt", binary = FALSE)
-})
-
-testthat::test_that("read_file_text returns the strings correctly", {
   local_edition(3)
-  fc <- list(fc1, fc2)
-  df <- fc[[1]][["df"]]
-  testthat::expect_snapshot_file(save_txt(read_file_text(df[1, "path_abs"])), "read_file_text1.txt", binary = FALSE)
-  testthat::expect_snapshot_file(save_txt(read_file_text(df[2, "path_abs"])), "read_file_text2.txt", binary = FALSE)
-  testthat::expect_snapshot_file(save_txt(read_file_text(df[3, "path_abs"])), "read_file_text3.txt", binary = FALSE)
-  testthat::expect_snapshot_file(save_txt(read_file_text(df[4, "path_abs"])), "read_file_text4.txt", binary = FALSE)
-  testthat::expect_snapshot_file(save_txt(read_file_text(df[5, "path_abs"])), "read_file_text5.txt", binary = FALSE)
+  expect_snapshot_file(save_txt(res), "file_to_vec.txt")
 })
 
-testthat::test_that("get_file_size returns the correct file size", {
-  fc <- list(fc1, fc2)
+test_that("read_file_text returns the strings correctly", {
+  res <- create_artifacts_pack()
+  fc <- list(res$fc1, res$fc2)
+  df <- fc[[1]][["df"]]
+
+  local_edition(3)
+  expect_snapshot_file(save_txt(read_file_text(df[1, "path_abs"])), "read_file_text1.txt")
+  expect_snapshot_file(save_txt(read_file_text(df[2, "path_abs"])), "read_file_text2.txt")
+  expect_snapshot_file(save_txt(read_file_text(df[3, "path_abs"])), "read_file_text3.txt")
+  expect_snapshot_file(save_txt(read_file_text(df[4, "path_abs"])), "read_file_text4.txt")
+  expect_snapshot_file(save_txt(read_file_text(df[5, "path_abs"])), "read_file_text5.txt")
+})
+
+test_that("get_file_size returns the correct file size", {
+  res <- create_artifacts_pack()
+  fc <- list(res$fc1, res$fc2)
   df <- fc[[1]][["df"]]
   file <- df[1, "path_abs"]
   expected <- file.info(file)$size
   actual <- get_file_size(file)
-  testthat::expect_equal(expected, actual)
+  expect_equal(expected, actual)
 })
 
-testthat::test_that("readbin_to_chr read a binary file as string correctly", {
-  fc <- list(fc1, fc2)
+test_that("readbin_to_chr read a binary file as string correctly", {
+  res <- create_artifacts_pack()
+  fc <- list(res$fc1, res$fc2)
   df <- fc[[1]][["df"]]
   path <- df[1, "path_abs"]
   expected <- as.character(readBin(path, what = "raw", n = get_file_size(path)))
   actual <- readbin_to_char(path)
-  testthat::expect_equal(expected, actual)
+  expect_equal(expected, actual)
 })

--- a/tests/testthat/test-independent_test_unpack.R
+++ b/tests/testthat/test-independent_test_unpack.R
@@ -1,96 +1,80 @@
-# locate example package path
-find_package <- function(pkg) {
-  system.file(paste0("examples/", pkg), package = "pkglite")
-}
-
-# list files under a folder in an example package
-find_files <- function(pkg, dir, pattern) {
-  pkg_path <- find_package(pkg)
-  d <- file.path(paste(pkg_path, dir, sep = "/")) %>%
-    list.files(
-      pattern = pattern,
-      ignore.case = TRUE,
-      full.names = TRUE
-    ) %>%
-    gsub(pattern = paste0(".*", pkg, "/{1}"), replacement = "") %>%
-    as.data.frame(stringsAsFactors = FALSE)
-  names(d)[1] <- "files"
-  d
-}
-
-pkg1 <- "pkg1" %>% find_package()
-pkg2 <- "pkg2" %>% find_package()
-fc1 <- pkg1 %>% collate(file_r())
-fc2 <- pkg2 %>% collate(file_r())
-txt <- tempfile(fileext = ".txt")
-
-pack(fc1, fc2, output = txt, quiet = TRUE)
-
-testthat::test_that("unpack returns the right files", {
+test_that("unpack returns the right files", {
+  res <- create_artifacts_unpack()
   out <- file.path(tempdir(), "twopkgs")
-  txt %>% unpack(output = out, quiet = TRUE)
-  testthat::expect_equal(
+  res$txt %>% unpack(output = out, quiet = TRUE)
+
+  expect_equal(
     out %>% file.path("pkg1/R") %>% list.files(),
-    pkg1 %>% file.path("/R") %>% list.files()
+    res$pkg1 %>% file.path("/R") %>% list.files()
   )
-  testthat::expect_equal(
+  expect_equal(
     out %>% file.path("pkg2/R") %>% list.files(),
-    pkg2 %>% file.path("/R") %>% list.files()
+    res$pkg2 %>% file.path("/R") %>% list.files()
   )
 })
 
-testthat::test_that("unpack returns error when input is not in the right format", {
+test_that("unpack returns error when input is not in the right format", {
   out <- file.path(tempdir(), "twopkgs")
-  testthat::expect_error(unpack(output = out, quiet = TRUE))
+  expect_error(unpack(output = out, quiet = TRUE))
 })
 
-testthat::test_that("unpack can successfully install the packages after unpacking", {
+test_that("unpack can successfully install the packages after unpacking", {
   skip_on_cran()
+
   pkg1 <- "pkg1" %>% find_package()
   pkg2 <- "pkg2" %>% find_package()
   fc1 <- pkg1 %>% collate(file_default())
   fc2 <- pkg2 %>% collate(file_default())
   txt <- tempfile(fileext = ".txt")
   pack(fc1, fc2, output = txt, quiet = TRUE)
+
   out <- file.path(tempdir(), "twopkgs")
   temp_lib <- file.path(tempdir(), "templib")
   invisible(dir.create(temp_lib))
   txt %>% unpack(output = out, quiet = TRUE, install = TRUE, lib = temp_lib, force = TRUE)
-  testthat::expect_true("pkg1" %in% list.files(temp_lib))
-  testthat::expect_true("pkg2" %in% list.files(temp_lib))
+
+  expect_true("pkg1" %in% list.files(temp_lib))
+  expect_true("pkg2" %in% list.files(temp_lib))
+
   unlink(temp_lib, recursive = TRUE)
 })
 
-testthat::test_that("read_pkglite returns the pkg names correctly", {
-  res <- read_pkglite(txt)
-  testthat::expect_equal(res$pkg_name %>% unique(), c("pkg1", "pkg2"))
+test_that("read_pkglite returns the pkg names correctly", {
+  res <- create_artifacts_unpack()
+  pkg <- read_pkglite(res$txt)
+  expect_equal(pkg$pkg_name %>% unique(), c("pkg1", "pkg2"))
 })
 
-testthat::test_that("read_pkglite returns the file path correctly", {
-  actual <- read_pkglite(txt)
+test_that("read_pkglite returns the file path correctly", {
+  res <- create_artifacts_unpack()
+  actual <- read_pkglite(res$txt)
   temp1 <- "pkg1" %>% find_files(dir = "R", pattern = "")
   res1 <- temp1$files %>% gsub(pattern = ".*pkg1/", replacement = "")
   temp2 <- "pkg2" %>% find_files(dir = "R", pattern = "")
   res2 <- temp2$files %>% gsub(pattern = ".*pkg2/", replacement = "")
   expected <- c(res1, res2)
-  testthat::expect_equal(actual$path, expected)
+
+  expect_equal(actual$path, expected)
 })
 
-testthat::test_that("match_field returns zero integer when the input is not valid", {
-  testthat::expect_true(match_field("test", "Package") %>% length() == 0L)
-  testthat::expect_true(match_field(123, "Package") %>% length() == 0L)
-  testthat::expect_true(match_field("test", "Package") %>% length() == 0L)
+test_that("match_field returns zero integer when the input is not valid", {
+  expect_true(match_field("test", "Package") %>% length() == 0L)
+  expect_true(match_field(123, "Package") %>% length() == 0L)
+  expect_true(match_field("test", "Package") %>% length() == 0L)
 })
 
-testthat::test_that("match_field returns numerical vector", {
-  input <- readLines(txt)
-  testthat::expect_true(match_field(input, "Package") %>% is.numeric())
-  testthat::expect_true(match_field(input, "File") %>% is.numeric())
-  testthat::expect_true(match_field(input, "Format") %>% is.numeric())
+test_that("match_field returns numerical vector", {
+  res <- create_artifacts_unpack()
+  input <- readLines(res$txt)
+
+  expect_true(match_field(input, "Package") %>% is.numeric())
+  expect_true(match_field(input, "File") %>% is.numeric())
+  expect_true(match_field(input, "Format") %>% is.numeric())
 })
 
-testthat::test_that("extract_value returns the file path correctly", {
-  input <- readLines(txt)
+test_that("extract_value returns the file path correctly", {
+  res <- create_artifacts_unpack()
+  input <- readLines(res$txt)
   ind <- match_field(input, "File")
   actual <- extract_value(input[ind])
   temp1 <- "pkg1" %>% find_files(dir = "R", pattern = "")
@@ -98,11 +82,12 @@ testthat::test_that("extract_value returns the file path correctly", {
   temp2 <- "pkg2" %>% find_files(dir = "R", pattern = "")
   res2 <- temp2$files %>% gsub(pattern = ".*pkg2/", replacement = "")
   expected <- c(res1, res2)
-  testthat::expect_equal(actual, expected)
+
+  expect_equal(actual, expected)
 })
 
-testthat::test_that("split_str_by_two returns the output as expected", {
+test_that("split_str_by_two returns the output as expected", {
   x <- "hello world"
-  testthat::expect_type(split_str_by_two(x), "character")
-  testthat::expect_equal(split_str_by_two(x) %>% length(), 6)
+  expect_type(split_str_by_two(x), "character")
+  expect_equal(split_str_by_two(x) %>% length(), 6)
 })


### PR DESCRIPTION
This PR moves the test logic that previously has "test file scope" into `tests/testthat/helper.R`.

This follows the best practice recommended in [R Packages](https://r-pkgs.org/testing-design.html).