### PR TITLE
Update `NEWS.md` for pkglite 0.2.2 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkglite
 Title: Compact Package Representations
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(
     person("Nan", "Xiao", email = "nan.xiao1@merck.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0250-5673")),
@@ -25,9 +25,9 @@ Imports:
     magrittr,
     remotes
 Suggests:
+    covr,
     knitr,
     rmarkdown,
-    testthat,
-    covr
+    testthat
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# pkglite 0.2.2
+
+## Enhancements
+
+- Move previous test logic that has "test file scope" into
+  `tests/testthat/helper.R` to follow best practices (#45).
+
 # pkglite 0.2.1
 
 ## Enhancements


### PR DESCRIPTION
This PR updates `NEWS.md` for pkglite 0.2.2 release and bumps the version number in `DESCRIPTION`.

Part of the release checklist in https://github.com/Merck/pkglite/issues/46.