### PR TITLE
Expand file extension dictionary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,4 +30,4 @@ Suggests:
     rmarkdown,
     testthat
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -39,27 +39,42 @@ ext_text <- function(flat = FALSE) {
     "man" = c("Rd", "rd"),
     "manfigures" = c("svg"),
     "src" = c(
-      "c", "h", "cpp", "cc", "hpp", "hxx", "hh",
+      "c", "h", "cpp", "cc", "ipp", "cxx", "hpp", "hxx", "hh", "cu", "cuh",
       "f", "f90", "f95", "f03",
-      "win", "in", "ucrt", "ac"
+      "win", "in", "ucrt", "ac", "mk", "guess"
     ),
     "vignette" = c(
-      "Rmd", "md", "csl", "Rnw", "tex", "ltx", "rsp", "cls", "sty",
-      "bib", "bst", "asis", "el"
+      "Rmd", "qmd", "orig", "md", "tex", "csl", "Rnw", "Snw", "Rtex", "Stex",
+      "rsp", "Rasciidoc", "Rhtml", "lyx", "ltx", "dtx", "cls", "sty", "aux",
+      "bib", "bibtex", "bst", "bbl", "asis", "el"
     ),
-    "meta" = c("Rproj", "dcf", "yml", "yaml", "note"),
+    "meta" = c("Rproj", "dcf", "yml", "yaml", "toml", "note"),
     "table" = c("csv", "tsv", "txt"),
-    "figure" = c("svg"),
-    "web" = c("html", "htm", "shtml", "css", "js", "json", "xml", "scss", "less"),
+    "figure" = c("svg", "ps", "dot", "drawio"),
+    "web" = c(
+      "html", "htm", "shtml", "css", "scss", "sass", "less",
+      "js", "cjs", "mjs", "jsx", "wasm",
+      "json", "ndjson", "jsonl", "jsonld", "json5", "topojson",
+      "xml", "xsd", "xsl", "xslt", "dtd"
+    ),
     "doc" = c("rtf"),
-    "log" = c("save", "Rout"),
+    "log" = c("save", "Rout", "log"),
     "proglang" = c(
       "stan", "bug", "jags", "py", "ipynb", "sh", "java", "bat", "m4", "cmake",
-      "sql", "lua", "rs", "jl", "pl", "pm", "brew"
+      "sql", "graphql", "lua", "rs", "lock", "jl", "pl", "pm", "brew",
+      "scala", "awk", "rb", "sas", "m", "asm"
     ),
     "gettext" = c("po", "pot"),
     "geo" = c("geojson", "kml", "prj", "cpg", "qpj"),
-    "bio" = c("fasta", "fastq", "vcf", "ped", "bim", "fam", "gff", "gtf")
+    "bio" = c(
+      "fasta", "fas", "fa", "faa", "fai",
+      "fastq", "vcf", "ped", "bim", "fam", "gff", "gff3", "gtf"
+    ),
+    "generic" = c(
+      "markdown", "rst", "typ",
+      "ini", "conf", "slurm", "ris", "cff",
+      "fwf", "arff", "graphml", "gexf"
+    )
   )
   if (flat) unique(unlist(x)) else x
 }
@@ -89,22 +104,27 @@ ext_binary <- function(flat = FALSE) {
     "figure" = c(
       "png", "jpg", "jpeg", "bmp", "gif", "tif", "tiff", "emf", "svgz",
       "ico", "webp", "eps", "pdf",
-      "ppm", "pgm", "pbm", "pnm"
+      "ppm", "pgm", "pbm", "pnm",
+      "xcf", "psd", "graffle"
     ),
     "src" = c("o", "so"),
     "build" = c("rdb", "rdx"),
     "web" = c("woff2", "woff", "otf", "ttf", "eot"),
-    "mso" = c("docx", "xlsx", "pptx", "xltx", "potx", "doc", "xls", "ppt"),
+    "mso" = c("docx", "xlsx", "pptx", "xltx", "potx", "doc", "xls", "ppt", "xlsb", "xlsm"),
     "odf" = c("odt", "ods", "odp", "odg", "odc", "odf", "odi", "odm", "odb"),
     "sas" = c("sas7bdat", "sas7bcat", "xpt", "xpt5", "xpt8"),
     "archive" = c("zip", "tar", "gz", "tgz", "bz2", "7z", "xz"),
-    "db" = c("sqlite", "sqlite3"),
+    "db" = c("sqlite", "sqlite3", "dbf", "accdb", "mdb"),
     "proglang" = c("pyc", "jar"),
     "gettext" = c("mo"),
     "geo" = c("shx", "shp", "laz", "sbx", "sbn", "nc", "gpkg"),
     "bio" = c("bam", "bai"),
     "audio" = c("wav", "mp3", "mid", "ogg", "au", "m4a"),
-    "video" = c("mp4", "avi", "mov", "mkv", "webm")
+    "video" = c("mp4", "avi", "mov", "mkv", "webm"),
+    "generic" = c(
+      "bin", "epub", "h5", "hdf5", "onnx",
+      "parquet", "feather", "pkl", "npy"
+    )
   )
   if (flat) unique(unlist(x)) else x
 }

--- a/tests/testthat/test-independent-test_dictionary.R
+++ b/tests/testthat/test-independent-test_dictionary.R
@@ -4,27 +4,42 @@ test_that("Test ext_text() generate the right string list", {
     "man" = c("Rd", "rd"),
     "manfigures" = c("svg"),
     "src" = c(
-      "c", "h", "cpp", "cc", "hpp", "hxx", "hh",
+      "c", "h", "cpp", "cc", "ipp", "cxx", "hpp", "hxx", "hh", "cu", "cuh",
       "f", "f90", "f95", "f03",
-      "win", "in", "ucrt", "ac"
+      "win", "in", "ucrt", "ac", "mk", "guess"
     ),
     "vignette" = c(
-      "Rmd", "md", "csl", "Rnw", "tex", "ltx", "rsp", "cls", "sty",
-      "bib", "bst", "asis", "el"
+      "Rmd", "qmd", "orig", "md", "tex", "csl", "Rnw", "Snw", "Rtex", "Stex",
+      "rsp", "Rasciidoc", "Rhtml", "lyx", "ltx", "dtx", "cls", "sty", "aux",
+      "bib", "bibtex", "bst", "bbl", "asis", "el"
     ),
-    "meta" = c("Rproj", "dcf", "yml", "yaml", "note"),
+    "meta" = c("Rproj", "dcf", "yml", "yaml", "toml", "note"),
     "table" = c("csv", "tsv", "txt"),
-    "figure" = c("svg"),
-    "web" = c("html", "htm", "shtml", "css", "js", "json", "xml", "scss", "less"),
+    "figure" = c("svg", "ps", "dot", "drawio"),
+    "web" = c(
+      "html", "htm", "shtml", "css", "scss", "sass", "less",
+      "js", "cjs", "mjs", "jsx", "wasm",
+      "json", "ndjson", "jsonl", "jsonld", "json5", "topojson",
+      "xml", "xsd", "xsl", "xslt", "dtd"
+    ),
     "doc" = c("rtf"),
-    "log" = c("save", "Rout"),
+    "log" = c("save", "Rout", "log"),
     "proglang" = c(
       "stan", "bug", "jags", "py", "ipynb", "sh", "java", "bat", "m4", "cmake",
-      "sql", "lua", "rs", "jl", "pl", "pm", "brew"
+      "sql", "graphql", "lua", "rs", "lock", "jl", "pl", "pm", "brew",
+      "scala", "awk", "rb", "sas", "m", "asm"
     ),
     "gettext" = c("po", "pot"),
     "geo" = c("geojson", "kml", "prj", "cpg", "qpj"),
-    "bio" = c("fasta", "fastq", "vcf", "ped", "bim", "fam", "gff", "gtf")
+    "bio" = c(
+      "fasta", "fas", "fa", "faa", "fai",
+      "fastq", "vcf", "ped", "bim", "fam", "gff", "gff3", "gtf"
+    ),
+    "generic" = c(
+      "markdown", "rst", "typ",
+      "ini", "conf", "slurm", "ris", "cff",
+      "fwf", "arff", "graphml", "gexf"
+    )
   )
 
   ls_target <- str_ls
@@ -44,22 +59,27 @@ test_that("Test ext_binary() generate the right string list", {
     "figure" = c(
       "png", "jpg", "jpeg", "bmp", "gif", "tif", "tiff", "emf", "svgz",
       "ico", "webp", "eps", "pdf",
-      "ppm", "pgm", "pbm", "pnm"
+      "ppm", "pgm", "pbm", "pnm",
+      "xcf", "psd", "graffle"
     ),
     "src" = c("o", "so"),
     "build" = c("rdb", "rdx"),
     "web" = c("woff2", "woff", "otf", "ttf", "eot"),
-    "mso" = c("docx", "xlsx", "pptx", "xltx", "potx", "doc", "xls", "ppt"),
+    "mso" = c("docx", "xlsx", "pptx", "xltx", "potx", "doc", "xls", "ppt", "xlsb", "xlsm"),
     "odf" = c("odt", "ods", "odp", "odg", "odc", "odf", "odi", "odm", "odb"),
     "sas" = c("sas7bdat", "sas7bcat", "xpt", "xpt5", "xpt8"),
     "archive" = c("zip", "tar", "gz", "tgz", "bz2", "7z", "xz"),
-    "db" = c("sqlite", "sqlite3"),
+    "db" = c("sqlite", "sqlite3", "dbf", "accdb", "mdb"),
     "proglang" = c("pyc", "jar"),
     "gettext" = c("mo"),
     "geo" = c("shx", "shp", "laz", "sbx", "sbn", "nc", "gpkg"),
     "bio" = c("bam", "bai"),
     "audio" = c("wav", "mp3", "mid", "ogg", "au", "m4a"),
-    "video" = c("mp4", "avi", "mov", "mkv", "webm")
+    "video" = c("mp4", "avi", "mov", "mkv", "webm"),
+    "generic" = c(
+      "bin", "epub", "h5", "hdf5", "onnx",
+      "parquet", "feather", "pkl", "npy"
+    )
   )
 
   ls_target <- str_ls

--- a/tests/testthat/test-independent-test_templates.R
+++ b/tests/testthat/test-independent-test_templates.R
@@ -127,7 +127,7 @@ test_that("file_src() creates the correct 'file_spec' object", {
   is_src <- is_file_spec_type(
     fs_source = file_src(),
     path = "src/",
-    pattern = "\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$",
+    pattern = "\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.ipp$|\\.cxx$|\\.hpp$|\\.hxx$|\\.hh$|\\.cu$|\\.cuh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.mk$|\\.guess$",
     format = "text",
     recursive = TRUE,
     ignore_case = TRUE,
@@ -164,7 +164,7 @@ test_that("file_vignettes() creates the correct 'file_spec' objects", {
       if (!is_spec_text & is_file_spec_type(
         fs_source = fs,
         path = "vignettes/",
-        pattern = "\\.R$|\\.r$|\\.s$|\\.q$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.Rmd$|\\.md$|\\.csl$|\\.Rnw$|\\.tex$|\\.ltx$|\\.rsp$|\\.cls$|\\.sty$|\\.bib$|\\.bst$|\\.asis$|\\.el$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.note$|\\.csv$|\\.tsv$|\\.txt$|\\.html$|\\.htm$|\\.shtml$|\\.css$|\\.js$|\\.json$|\\.xml$|\\.scss$|\\.less$|\\.rtf$|\\.save$|\\.Rout$|\\.stan$|\\.bug$|\\.jags$|\\.py$|\\.ipynb$|\\.sh$|\\.java$|\\.bat$|\\.m4$|\\.cmake$|\\.sql$|\\.lua$|\\.rs$|\\.jl$|\\.pl$|\\.pm$|\\.brew$|\\.po$|\\.pot$|\\.geojson$|\\.kml$|\\.prj$|\\.cpg$|\\.qpj$|\\.fasta$|\\.fastq$|\\.vcf$|\\.ped$|\\.bim$|\\.fam$|\\.gff$|\\.gtf$",
+        pattern = "\\.R$|\\.r$|\\.s$|\\.q$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.ipp$|\\.cxx$|\\.hpp$|\\.hxx$|\\.hh$|\\.cu$|\\.cuh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.mk$|\\.guess$|\\.Rmd$|\\.qmd$|\\.orig$|\\.md$|\\.tex$|\\.csl$|\\.Rnw$|\\.Snw$|\\.Rtex$|\\.Stex$|\\.rsp$|\\.Rasciidoc$|\\.Rhtml$|\\.lyx$|\\.ltx$|\\.dtx$|\\.cls$|\\.sty$|\\.aux$|\\.bib$|\\.bibtex$|\\.bst$|\\.bbl$|\\.asis$|\\.el$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.toml$|\\.note$|\\.csv$|\\.tsv$|\\.txt$|\\.ps$|\\.dot$|\\.drawio$|\\.html$|\\.htm$|\\.shtml$|\\.css$|\\.scss$|\\.sass$|\\.less$|\\.js$|\\.cjs$|\\.mjs$|\\.jsx$|\\.wasm$|\\.json$|\\.ndjson$|\\.jsonl$|\\.jsonld$|\\.json5$|\\.topojson$|\\.xml$|\\.xsd$|\\.xsl$|\\.xslt$|\\.dtd$|\\.rtf$|\\.save$|\\.Rout$|\\.log$|\\.stan$|\\.bug$|\\.jags$|\\.py$|\\.ipynb$|\\.sh$|\\.java$|\\.bat$|\\.m4$|\\.cmake$|\\.sql$|\\.graphql$|\\.lua$|\\.rs$|\\.lock$|\\.jl$|\\.pl$|\\.pm$|\\.brew$|\\.scala$|\\.awk$|\\.rb$|\\.sas$|\\.m$|\\.asm$|\\.po$|\\.pot$|\\.geojson$|\\.kml$|\\.prj$|\\.cpg$|\\.qpj$|\\.fasta$|\\.fas$|\\.fa$|\\.faa$|\\.fai$|\\.fastq$|\\.vcf$|\\.ped$|\\.bim$|\\.fam$|\\.gff$|\\.gff3$|\\.gtf$|\\.markdown$|\\.rst$|\\.typ$|\\.ini$|\\.conf$|\\.slurm$|\\.ris$|\\.cff$|\\.fwf$|\\.arff$|\\.graphml$|\\.gexf$",
         format = "text",
         recursive = TRUE,
         ignore_case = TRUE,
@@ -176,7 +176,7 @@ test_that("file_vignettes() creates the correct 'file_spec' objects", {
       (!is_spec_binary & is_file_spec_type(
           fs_source = fs,
           path = "vignettes/",
-          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tif$|\\.tiff$|\\.emf$|\\.svgz$|\\.ico$|\\.webp$|\\.eps$|\\.ppm$|\\.pgm$|\\.pbm$|\\.pnm$|\\.o$|\\.so$|\\.rdb$|\\.rdx$|\\.woff2$|\\.woff$|\\.otf$|\\.ttf$|\\.eot$|\\.docx$|\\.xlsx$|\\.pptx$|\\.xltx$|\\.potx$|\\.doc$|\\.xls$|\\.ppt$|\\.odt$|\\.ods$|\\.odp$|\\.odg$|\\.odc$|\\.odf$|\\.odi$|\\.odm$|\\.odb$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$|\\.zip$|\\.tar$|\\.gz$|\\.tgz$|\\.bz2$|\\.7z$|\\.xz$|\\.sqlite$|\\.sqlite3$|\\.pyc$|\\.jar$|\\.mo$|\\.shx$|\\.shp$|\\.laz$|\\.sbx$|\\.sbn$|\\.nc$|\\.gpkg$|\\.bam$|\\.bai$|\\.wav$|\\.mp3$|\\.mid$|\\.ogg$|\\.au$|\\.m4a$|\\.mp4$|\\.avi$|\\.mov$|\\.mkv$|\\.webm$",
+          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tif$|\\.tiff$|\\.emf$|\\.svgz$|\\.ico$|\\.webp$|\\.eps$|\\.ppm$|\\.pgm$|\\.pbm$|\\.pnm$|\\.xcf$|\\.psd$|\\.graffle$|\\.o$|\\.so$|\\.rdb$|\\.rdx$|\\.woff2$|\\.woff$|\\.otf$|\\.ttf$|\\.eot$|\\.docx$|\\.xlsx$|\\.pptx$|\\.xltx$|\\.potx$|\\.doc$|\\.xls$|\\.ppt$|\\.xlsb$|\\.xlsm$|\\.odt$|\\.ods$|\\.odp$|\\.odg$|\\.odc$|\\.odf$|\\.odi$|\\.odm$|\\.odb$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$|\\.zip$|\\.tar$|\\.gz$|\\.tgz$|\\.bz2$|\\.7z$|\\.xz$|\\.sqlite$|\\.sqlite3$|\\.dbf$|\\.accdb$|\\.mdb$|\\.pyc$|\\.jar$|\\.mo$|\\.shx$|\\.shp$|\\.laz$|\\.sbx$|\\.sbn$|\\.nc$|\\.gpkg$|\\.bam$|\\.bai$|\\.wav$|\\.mp3$|\\.mid$|\\.ogg$|\\.au$|\\.m4a$|\\.mp4$|\\.avi$|\\.mov$|\\.mkv$|\\.webm$|\\.bin$|\\.epub$|\\.h5$|\\.hdf5$|\\.onnx$|\\.parquet$|\\.feather$|\\.pkl$|\\.npy$",
           format = "binary",
           recursive = TRUE,
           ignore_case = TRUE,
@@ -285,7 +285,7 @@ test_that("file_default() creates the correct 'file_spec' objects", {
       (!is_src & is_file_spec_type(
           fs_source = fs,
           path = "src/",
-          pattern = "\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$",
+          pattern = "\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.ipp$|\\.cxx$|\\.hpp$|\\.hxx$|\\.hh$|\\.cu$|\\.cuh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.mk$|\\.guess$",
           format = "text",
           recursive = TRUE,
           ignore_case = TRUE,
@@ -296,7 +296,7 @@ test_that("file_default() creates the correct 'file_spec' objects", {
       } else if (!is_spec_text & is_file_spec_type(
         fs_source = fs,
         path = "vignettes/",
-        pattern = "\\.R$|\\.r$|\\.s$|\\.q$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.Rmd$|\\.md$|\\.csl$|\\.Rnw$|\\.tex$|\\.ltx$|\\.rsp$|\\.cls$|\\.sty$|\\.bib$|\\.bst$|\\.asis$|\\.el$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.note$|\\.csv$|\\.tsv$|\\.txt$|\\.html$|\\.htm$|\\.shtml$|\\.css$|\\.js$|\\.json$|\\.xml$|\\.scss$|\\.less$|\\.rtf$|\\.save$|\\.Rout$|\\.stan$|\\.bug$|\\.jags$|\\.py$|\\.ipynb$|\\.sh$|\\.java$|\\.bat$|\\.m4$|\\.cmake$|\\.sql$|\\.lua$|\\.rs$|\\.jl$|\\.pl$|\\.pm$|\\.brew$|\\.po$|\\.pot$|\\.geojson$|\\.kml$|\\.prj$|\\.cpg$|\\.qpj$|\\.fasta$|\\.fastq$|\\.vcf$|\\.ped$|\\.bim$|\\.fam$|\\.gff$|\\.gtf$",
+        pattern = "\\.R$|\\.r$|\\.s$|\\.q$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.ipp$|\\.cxx$|\\.hpp$|\\.hxx$|\\.hh$|\\.cu$|\\.cuh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.mk$|\\.guess$|\\.Rmd$|\\.qmd$|\\.orig$|\\.md$|\\.tex$|\\.csl$|\\.Rnw$|\\.Snw$|\\.Rtex$|\\.Stex$|\\.rsp$|\\.Rasciidoc$|\\.Rhtml$|\\.lyx$|\\.ltx$|\\.dtx$|\\.cls$|\\.sty$|\\.aux$|\\.bib$|\\.bibtex$|\\.bst$|\\.bbl$|\\.asis$|\\.el$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.toml$|\\.note$|\\.csv$|\\.tsv$|\\.txt$|\\.ps$|\\.dot$|\\.drawio$|\\.html$|\\.htm$|\\.shtml$|\\.css$|\\.scss$|\\.sass$|\\.less$|\\.js$|\\.cjs$|\\.mjs$|\\.jsx$|\\.wasm$|\\.json$|\\.ndjson$|\\.jsonl$|\\.jsonld$|\\.json5$|\\.topojson$|\\.xml$|\\.xsd$|\\.xsl$|\\.xslt$|\\.dtd$|\\.rtf$|\\.save$|\\.Rout$|\\.log$|\\.stan$|\\.bug$|\\.jags$|\\.py$|\\.ipynb$|\\.sh$|\\.java$|\\.bat$|\\.m4$|\\.cmake$|\\.sql$|\\.graphql$|\\.lua$|\\.rs$|\\.lock$|\\.jl$|\\.pl$|\\.pm$|\\.brew$|\\.scala$|\\.awk$|\\.rb$|\\.sas$|\\.m$|\\.asm$|\\.po$|\\.pot$|\\.geojson$|\\.kml$|\\.prj$|\\.cpg$|\\.qpj$|\\.fasta$|\\.fas$|\\.fa$|\\.faa$|\\.fai$|\\.fastq$|\\.vcf$|\\.ped$|\\.bim$|\\.fam$|\\.gff$|\\.gff3$|\\.gtf$|\\.markdown$|\\.rst$|\\.typ$|\\.ini$|\\.conf$|\\.slurm$|\\.ris$|\\.cff$|\\.fwf$|\\.arff$|\\.graphml$|\\.gexf$",
         format = "text",
         recursive = TRUE,
         ignore_case = TRUE,
@@ -308,7 +308,7 @@ test_that("file_default() creates the correct 'file_spec' objects", {
       (!is_spec_binary & is_file_spec_type(
           fs_source = fs,
           path = "vignettes/",
-          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tif$|\\.tiff$|\\.emf$|\\.svgz$|\\.ico$|\\.webp$|\\.eps$|\\.ppm$|\\.pgm$|\\.pbm$|\\.pnm$|\\.o$|\\.so$|\\.rdb$|\\.rdx$|\\.woff2$|\\.woff$|\\.otf$|\\.ttf$|\\.eot$|\\.docx$|\\.xlsx$|\\.pptx$|\\.xltx$|\\.potx$|\\.doc$|\\.xls$|\\.ppt$|\\.odt$|\\.ods$|\\.odp$|\\.odg$|\\.odc$|\\.odf$|\\.odi$|\\.odm$|\\.odb$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$|\\.zip$|\\.tar$|\\.gz$|\\.tgz$|\\.bz2$|\\.7z$|\\.xz$|\\.sqlite$|\\.sqlite3$|\\.pyc$|\\.jar$|\\.mo$|\\.shx$|\\.shp$|\\.laz$|\\.sbx$|\\.sbn$|\\.nc$|\\.gpkg$|\\.bam$|\\.bai$|\\.wav$|\\.mp3$|\\.mid$|\\.ogg$|\\.au$|\\.m4a$|\\.mp4$|\\.avi$|\\.mov$|\\.mkv$|\\.webm$",
+          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tif$|\\.tiff$|\\.emf$|\\.svgz$|\\.ico$|\\.webp$|\\.eps$|\\.ppm$|\\.pgm$|\\.pbm$|\\.pnm$|\\.xcf$|\\.psd$|\\.graffle$|\\.o$|\\.so$|\\.rdb$|\\.rdx$|\\.woff2$|\\.woff$|\\.otf$|\\.ttf$|\\.eot$|\\.docx$|\\.xlsx$|\\.pptx$|\\.xltx$|\\.potx$|\\.doc$|\\.xls$|\\.ppt$|\\.xlsb$|\\.xlsm$|\\.odt$|\\.ods$|\\.odp$|\\.odg$|\\.odc$|\\.odf$|\\.odi$|\\.odm$|\\.odb$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$|\\.zip$|\\.tar$|\\.gz$|\\.tgz$|\\.bz2$|\\.7z$|\\.xz$|\\.sqlite$|\\.sqlite3$|\\.dbf$|\\.accdb$|\\.mdb$|\\.pyc$|\\.jar$|\\.mo$|\\.shx$|\\.shp$|\\.laz$|\\.sbx$|\\.sbn$|\\.nc$|\\.gpkg$|\\.bam$|\\.bai$|\\.wav$|\\.mp3$|\\.mid$|\\.ogg$|\\.au$|\\.m4a$|\\.mp4$|\\.avi$|\\.mov$|\\.mkv$|\\.webm$|\\.bin$|\\.epub$|\\.h5$|\\.hdf5$|\\.onnx$|\\.parquet$|\\.feather$|\\.pkl$|\\.npy$",
           format = "binary",
           recursive = TRUE,
           ignore_case = TRUE,
@@ -437,7 +437,7 @@ test_that("file_ectd() creates the correct 'file_spec' objects", {
       (!is_src & is_file_spec_type(
           fs_source = fs,
           path = "src/",
-          pattern = "\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$",
+          pattern = "\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.ipp$|\\.cxx$|\\.hpp$|\\.hxx$|\\.hh$|\\.cu$|\\.cuh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.mk$|\\.guess$",
           format = "text",
           recursive = TRUE,
           ignore_case = TRUE,
@@ -484,7 +484,7 @@ test_that("file_auto() creates the correct 'file_spec' objects", {
       if (!is_spec_text & is_file_spec_type(
         fs_source = fs,
         path = "inst/",
-        pattern = "\\.R$|\\.r$|\\.s$|\\.q$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.hpp$|\\.hxx$|\\.hh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.Rmd$|\\.md$|\\.csl$|\\.Rnw$|\\.tex$|\\.ltx$|\\.rsp$|\\.cls$|\\.sty$|\\.bib$|\\.bst$|\\.asis$|\\.el$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.note$|\\.csv$|\\.tsv$|\\.txt$|\\.html$|\\.htm$|\\.shtml$|\\.css$|\\.js$|\\.json$|\\.xml$|\\.scss$|\\.less$|\\.rtf$|\\.save$|\\.Rout$|\\.stan$|\\.bug$|\\.jags$|\\.py$|\\.ipynb$|\\.sh$|\\.java$|\\.bat$|\\.m4$|\\.cmake$|\\.sql$|\\.lua$|\\.rs$|\\.jl$|\\.pl$|\\.pm$|\\.brew$|\\.po$|\\.pot$|\\.geojson$|\\.kml$|\\.prj$|\\.cpg$|\\.qpj$|\\.fasta$|\\.fastq$|\\.vcf$|\\.ped$|\\.bim$|\\.fam$|\\.gff$|\\.gtf$",
+        pattern = "\\.R$|\\.r$|\\.s$|\\.q$|\\.Rd$|\\.rd$|\\.svg$|\\.c$|\\.h$|\\.cpp$|\\.cc$|\\.ipp$|\\.cxx$|\\.hpp$|\\.hxx$|\\.hh$|\\.cu$|\\.cuh$|\\.f$|\\.f90$|\\.f95$|\\.f03$|\\.win$|\\.in$|\\.ucrt$|\\.ac$|\\.mk$|\\.guess$|\\.Rmd$|\\.qmd$|\\.orig$|\\.md$|\\.tex$|\\.csl$|\\.Rnw$|\\.Snw$|\\.Rtex$|\\.Stex$|\\.rsp$|\\.Rasciidoc$|\\.Rhtml$|\\.lyx$|\\.ltx$|\\.dtx$|\\.cls$|\\.sty$|\\.aux$|\\.bib$|\\.bibtex$|\\.bst$|\\.bbl$|\\.asis$|\\.el$|\\.Rproj$|\\.dcf$|\\.yml$|\\.yaml$|\\.toml$|\\.note$|\\.csv$|\\.tsv$|\\.txt$|\\.ps$|\\.dot$|\\.drawio$|\\.html$|\\.htm$|\\.shtml$|\\.css$|\\.scss$|\\.sass$|\\.less$|\\.js$|\\.cjs$|\\.mjs$|\\.jsx$|\\.wasm$|\\.json$|\\.ndjson$|\\.jsonl$|\\.jsonld$|\\.json5$|\\.topojson$|\\.xml$|\\.xsd$|\\.xsl$|\\.xslt$|\\.dtd$|\\.rtf$|\\.save$|\\.Rout$|\\.log$|\\.stan$|\\.bug$|\\.jags$|\\.py$|\\.ipynb$|\\.sh$|\\.java$|\\.bat$|\\.m4$|\\.cmake$|\\.sql$|\\.graphql$|\\.lua$|\\.rs$|\\.lock$|\\.jl$|\\.pl$|\\.pm$|\\.brew$|\\.scala$|\\.awk$|\\.rb$|\\.sas$|\\.m$|\\.asm$|\\.po$|\\.pot$|\\.geojson$|\\.kml$|\\.prj$|\\.cpg$|\\.qpj$|\\.fasta$|\\.fas$|\\.fa$|\\.faa$|\\.fai$|\\.fastq$|\\.vcf$|\\.ped$|\\.bim$|\\.fam$|\\.gff$|\\.gff3$|\\.gtf$|\\.markdown$|\\.rst$|\\.typ$|\\.ini$|\\.conf$|\\.slurm$|\\.ris$|\\.cff$|\\.fwf$|\\.arff$|\\.graphml$|\\.gexf$",
         format = "text",
         recursive = TRUE,
         ignore_case = TRUE,
@@ -496,7 +496,7 @@ test_that("file_auto() creates the correct 'file_spec' objects", {
       (!is_spec_binary & is_file_spec_type(
           fs_source = fs,
           path = "inst/",
-          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tif$|\\.tiff$|\\.emf$|\\.svgz$|\\.ico$|\\.webp$|\\.eps$|\\.ppm$|\\.pgm$|\\.pbm$|\\.pnm$|\\.o$|\\.so$|\\.rdb$|\\.rdx$|\\.woff2$|\\.woff$|\\.otf$|\\.ttf$|\\.eot$|\\.docx$|\\.xlsx$|\\.pptx$|\\.xltx$|\\.potx$|\\.doc$|\\.xls$|\\.ppt$|\\.odt$|\\.ods$|\\.odp$|\\.odg$|\\.odc$|\\.odf$|\\.odi$|\\.odm$|\\.odb$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$|\\.zip$|\\.tar$|\\.gz$|\\.tgz$|\\.bz2$|\\.7z$|\\.xz$|\\.sqlite$|\\.sqlite3$|\\.pyc$|\\.jar$|\\.mo$|\\.shx$|\\.shp$|\\.laz$|\\.sbx$|\\.sbn$|\\.nc$|\\.gpkg$|\\.bam$|\\.bai$|\\.wav$|\\.mp3$|\\.mid$|\\.ogg$|\\.au$|\\.m4a$|\\.mp4$|\\.avi$|\\.mov$|\\.mkv$|\\.webm$",
+          pattern = "\\.rda$|\\.rds$|\\.RData$|\\.jpg$|\\.jpeg$|\\.pdf$|\\.png$|\\.bmp$|\\.gif$|\\.tif$|\\.tiff$|\\.emf$|\\.svgz$|\\.ico$|\\.webp$|\\.eps$|\\.ppm$|\\.pgm$|\\.pbm$|\\.pnm$|\\.xcf$|\\.psd$|\\.graffle$|\\.o$|\\.so$|\\.rdb$|\\.rdx$|\\.woff2$|\\.woff$|\\.otf$|\\.ttf$|\\.eot$|\\.docx$|\\.xlsx$|\\.pptx$|\\.xltx$|\\.potx$|\\.doc$|\\.xls$|\\.ppt$|\\.xlsb$|\\.xlsm$|\\.odt$|\\.ods$|\\.odp$|\\.odg$|\\.odc$|\\.odf$|\\.odi$|\\.odm$|\\.odb$|\\.sas7bdat$|\\.sas7bcat$|\\.xpt$|\\.xpt5$|\\.xpt8$|\\.zip$|\\.tar$|\\.gz$|\\.tgz$|\\.bz2$|\\.7z$|\\.xz$|\\.sqlite$|\\.sqlite3$|\\.dbf$|\\.accdb$|\\.mdb$|\\.pyc$|\\.jar$|\\.mo$|\\.shx$|\\.shp$|\\.laz$|\\.sbx$|\\.sbn$|\\.nc$|\\.gpkg$|\\.bam$|\\.bai$|\\.wav$|\\.mp3$|\\.mid$|\\.ogg$|\\.au$|\\.m4a$|\\.mp4$|\\.avi$|\\.mov$|\\.mkv$|\\.webm$|\\.bin$|\\.epub$|\\.h5$|\\.hdf5$|\\.onnx$|\\.parquet$|\\.feather$|\\.pkl$|\\.npy$",
           format = "binary",
           recursive = TRUE,
           ignore_case = TRUE,


### PR DESCRIPTION
This PR expands the file extension dictionary (text and binary) by using the latest [CRAN package data](https://nanx.me/blog/post/cran-file-exts/).

This increase the default file specifications coverage when discovering files.