### PR TITLE
Add citation key to `inst/CITATION`

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,5 +1,6 @@
 bibentry(
   "Article",
+  key = "zhao2023electronic",
   title = "Electronic common technical document submission with analysis using {R}",
   author = "Yujie Zhao and Nan Xiao and Keaven Anderson and Yilong Zhang",
   journal = "Clinical Trials",


### PR DESCRIPTION
This PR adds a BibTeX key to `inst/CITATION` so that the rendered BibTeX item is proper (with a key).